### PR TITLE
[Feat] 시큐리티 필터 분기처리 및 테스트코드 작성

### DIFF
--- a/src/main/java/com/tf4/photospot/auth/application/AuthService.java
+++ b/src/main/java/com/tf4/photospot/auth/application/AuthService.java
@@ -7,7 +7,6 @@ import com.tf4.photospot.auth.application.response.ReissueTokenResponse;
 import com.tf4.photospot.user.application.UserService;
 import com.tf4.photospot.user.domain.User;
 
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 
 @Transactional(readOnly = true)
@@ -18,10 +17,9 @@ public class AuthService {
 	private final UserService userService;
 	private final JwtService jwtService;
 
-	public ReissueTokenResponse reissueToken(String refreshToken) {
-		Claims claims = jwtService.parseRefreshToken(refreshToken);
-		User user = userService.findUser(claims.get("id", Long.class));
-		jwtService.validRefreshToken(user.getId(), refreshToken);
+	public ReissueTokenResponse reissueToken(Long userId, String refreshToken) {
+		jwtService.validRefreshToken(userId, refreshToken);
+		User user = userService.findUser(userId);
 		return new ReissueTokenResponse(jwtService.issueAccessToken(user.getId(), user.getRole().type));
 	}
 }

--- a/src/main/java/com/tf4/photospot/auth/presentation/AuthController.java
+++ b/src/main/java/com/tf4/photospot/auth/presentation/AuthController.java
@@ -1,5 +1,6 @@
 package com.tf4.photospot.auth.presentation;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import com.tf4.photospot.auth.application.AuthService;
 import com.tf4.photospot.auth.application.response.ReissueTokenResponse;
 import com.tf4.photospot.global.config.jwt.JwtConstant;
 import com.tf4.photospot.global.dto.ApiResponse;
+import com.tf4.photospot.global.dto.LoginUserDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,7 +23,8 @@ public class AuthController {
 
 	@GetMapping("/reissue")
 	public ApiResponse<ReissueTokenResponse> reissueToken(
+		@AuthenticationPrincipal LoginUserDto loginUserDto,
 		@CookieValue(JwtConstant.REFRESH_COOKIE_NAME) String refreshToken) {
-		return ApiResponse.success(authService.reissueToken(refreshToken));
+		return ApiResponse.success(authService.reissueToken(loginUserDto.getId(), refreshToken));
 	}
 }

--- a/src/main/java/com/tf4/photospot/global/dto/LoginUserDto.java
+++ b/src/main/java/com/tf4/photospot/global/dto/LoginUserDto.java
@@ -1,7 +1,9 @@
 package com.tf4.photospot.global.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 public class LoginUserDto {
 
 	@Getter
@@ -10,6 +12,7 @@ public class LoginUserDto {
 
 	public LoginUserDto(Long id) {
 		this.id = id;
+		hasLoggedInBefore = true;
 	}
 
 	public LoginUserDto(Long id, boolean hasLoggedInBefore) {

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -729,7 +729,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <hr>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/login?account=kakao%20account&amp;providerType=kakao HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/login?account=kakao_account&amp;providerType=kakao HTTP/1.1
 Content-Type: application/x-www-form-urlencoded
 Host: localhost:8080</code></pre>
 </div>
@@ -776,7 +776,7 @@ Host: localhost:8080</code></pre>
   "code" : "200",
   "message" : "OK",
   "data" : {
-    "accessToken" : "access token",
+    "accessToken" : "access_token",
     "hasLoggedInBefore" : false
   }
 }</code></pre>
@@ -824,7 +824,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/auth/reissue HTTP/1.1
 Host: localhost:8080
-Cookie: RefreshToken=refresh token value</code></pre>
+Cookie: RefreshToken=refresh_token_value</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -851,7 +851,7 @@ Cookie: RefreshToken=refresh token value</code></pre>
   "code" : "200",
   "message" : "OK",
   "data" : {
-    "accessToken" : "access_token"
+    "accessToken" : "new_access_token_value"
   }
 }</code></pre>
 </div>

--- a/src/test/java/com/tf4/photospot/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/tf4/photospot/auth/application/AuthServiceTest.java
@@ -5,13 +5,11 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.tf4.photospot.IntegrationTestSupport;
 import com.tf4.photospot.auth.application.response.ReissueTokenResponse;
 import com.tf4.photospot.user.application.UserService;
 
-@Transactional
 public class AuthServiceTest extends IntegrationTestSupport {
 
 	@Autowired
@@ -33,7 +31,7 @@ public class AuthServiceTest extends IntegrationTestSupport {
 		String refreshToken = jwtService.issueRefreshToken(loginUser);
 
 		// when
-		ReissueTokenResponse tokenResponse = authService.reissueToken(refreshToken);
+		ReissueTokenResponse tokenResponse = authService.reissueToken(loginUser, refreshToken);
 
 		// then
 		assertThat(tokenResponse.accessToken()).isNotBlank();

--- a/src/test/java/com/tf4/photospot/mockobject/RestDocsAuthenticationPrincipalArgumentResolver.java
+++ b/src/test/java/com/tf4/photospot/mockobject/RestDocsAuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,24 @@
+package com.tf4.photospot.mockobject;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.tf4.photospot.global.dto.LoginUserDto;
+
+public class RestDocsAuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		return new LoginUserDto(1L);
+	}
+}

--- a/src/test/java/com/tf4/photospot/mockobject/WithCustomMockUser.java
+++ b/src/test/java/com/tf4/photospot/mockobject/WithCustomMockUser.java
@@ -1,4 +1,4 @@
-package com.tf4.photospot.mockuser;
+package com.tf4.photospot.mockobject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,10 +8,10 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 import com.tf4.photospot.user.domain.Role;
 
 @Retention(RetentionPolicy.RUNTIME)
-@WithSecurityContext(factory = WithMockCustomerUserSecurityContextFactory.class)
-public @interface WithMockCustomUser {
+@WithSecurityContext(factory = WithCustomerMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
 
-	long id() default 1L;
+	long userId() default 1L;
 
 	boolean hasLoggedInBefore() default false;
 

--- a/src/test/java/com/tf4/photospot/mockobject/WithCustomerMockUserSecurityContextFactory.java
+++ b/src/test/java/com/tf4/photospot/mockobject/WithCustomerMockUserSecurityContextFactory.java
@@ -1,4 +1,4 @@
-package com.tf4.photospot.mockuser;
+package com.tf4.photospot.mockobject;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -10,16 +10,16 @@ import com.tf4.photospot.global.dto.LoginUserDto;
 import com.tf4.photospot.global.util.AuthorityConverter;
 import com.tf4.photospot.user.application.response.OauthLoginUserResponse;
 
-public class WithMockCustomerUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+public class WithCustomerMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
 
 	@Override
-	public SecurityContext createSecurityContext(WithMockCustomUser mockUser) {
-		SecurityContext context = SecurityContextHolder.createEmptyContext();
-		OauthLoginUserResponse loginUser = new OauthLoginUserResponse(mockUser.hasLoggedInBefore(), mockUser.id(),
+	public SecurityContext createSecurityContext(WithCustomMockUser mockUser) {
+		OauthLoginUserResponse loginUser = new OauthLoginUserResponse(mockUser.hasLoggedInBefore(), mockUser.userId(),
 			mockUser.role());
 		Authentication auth = new UsernamePasswordAuthenticationToken(
 			new LoginUserDto(loginUser.getId(), loginUser.hasLoggedInBefore()), null,
 			AuthorityConverter.convertStringToGrantedAuthority(loginUser.getRole().type));
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
 		context.setAuthentication(auth);
 		return context;
 	}

--- a/src/test/java/com/tf4/photospot/spot/presentation/SpotControllerTest.java
+++ b/src/test/java/com/tf4/photospot/spot/presentation/SpotControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import com.tf4.photospot.global.dto.CoordinateDto;
 import com.tf4.photospot.map.application.MapService;
 import com.tf4.photospot.map.application.response.SearchByCoordResponse;
-import com.tf4.photospot.mockuser.WithMockCustomUser;
+import com.tf4.photospot.mockobject.WithCustomMockUser;
 import com.tf4.photospot.post.application.response.PostPreviewResponse;
 import com.tf4.photospot.spot.application.SpotService;
 import com.tf4.photospot.spot.application.request.NearbySpotRequest;
@@ -34,7 +34,7 @@ import com.tf4.photospot.spot.application.response.NearbySpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotResponse;
 
-@WithMockCustomUser
+@WithCustomMockUser
 @WebMvcTest(controllers = SpotController.class)
 class SpotControllerTest {
 	@MockBean

--- a/src/test/java/com/tf4/photospot/spring/docs/RestDocsSupport.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/RestDocsSupport.java
@@ -21,6 +21,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tf4.photospot.global.argument.CoordinateValidator;
+import com.tf4.photospot.mockobject.RestDocsAuthenticationPrincipalArgumentResolver;
 
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class RestDocsSupport {
@@ -32,7 +33,9 @@ public abstract class RestDocsSupport {
 	void setUp(RestDocumentationContextProvider contextProvider) {
 		mockMvc = MockMvcBuilders.standaloneSetup(initController())
 			.apply(documentationConfiguration(contextProvider))
-			.setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+			.setCustomArgumentResolvers(
+				new PageableHandlerMethodArgumentResolver(),
+				new RestDocsAuthenticationPrincipalArgumentResolver())
 			.alwaysDo(MockMvcResultHandlers.print())
 			.addFilters(new CharacterEncodingFilter("UTF-8", true))
 			.build();

--- a/src/test/java/com/tf4/photospot/spring/docs/auth/AuthControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/auth/AuthControllerDocsTest.java
@@ -1,5 +1,6 @@
 package com.tf4.photospot.spring.docs.auth;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.cookies.CookieDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -30,12 +31,12 @@ public class AuthControllerDocsTest extends RestDocsSupport {
 	@Test
 	void reissueToken() throws Exception {
 		// given
-		var tokenResponse = new ReissueTokenResponse("access_token");
-		given(authService.reissueToken(any(String.class))).willReturn(tokenResponse);
+		var reissueResponse = new ReissueTokenResponse("new_access_token_value");
+		given(authService.reissueToken(anyLong(), anyString())).willReturn(reissueResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/auth/reissue")
-				.cookie(new Cookie("RefreshToken", "refresh token value"))
+				.cookie(new Cookie("RefreshToken", "refresh_token_value"))
 			)
 			.andExpect(status().isOk())
 			.andDo(restDocsTemplate(

--- a/src/test/java/com/tf4/photospot/spring/docs/auth/SecurityController.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/auth/SecurityController.java
@@ -16,8 +16,8 @@ public class SecurityController {
 
 	@PostMapping("/login")
 	public ApiResponse<LoginResponse> login(HttpServletResponse response) {
-		Cookie cookie = new Cookie("RefreshToken", "refresh token value");
+		Cookie cookie = new Cookie("RefreshToken", "refresh_token_value");
 		response.addCookie(cookie);
-		return ApiResponse.success(new LoginResponse("access token", false));
+		return ApiResponse.success(new LoginResponse("access_token", false));
 	}
 }


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- JwtTokenValidatorFilter에서 액세트 토큰 재발급 요청을 분기처리하여 리프레시 토큰을 기반으로 사용자 정보를 추출한 후 시큐리티 컨텍스트 홀더에 저장했습니다.
  - 액세스 토큰 재발급 API 통합 테스트 코드를 작성했습니다.
  - 액세스 토큰 재발급 API Rest Docs를 작성했습니다.
- 처음 로그인 할때는 LoginUserDto 생성 시 hasLoggedInBefore 필드 값을 넣어주고, 그 외 요청에서는 기본적으로 true로 설정되게 변경했습니다.
  - 현재 LoginUserDto를 Authentication Principal 객체로 사용하고 있는데 hasLoggedInBefore이 로그인 API에만 필요한 부분이기 때문에 추후 그 외 요청에 따른 Authentication Principal 객체를 분리하여 관리할 예정입니다. 나중에 블랙 회원이나 탈퇴 회원을 다룰 때 함께 수정하면 좋을 것 같습니다.

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

- 슬랙에서 말씀드린 대로 원래는 Rest Docs와 통합 테스트를 함께 두려고 했는데, 그렇게하니 RestDocs에 불필요한 정보(input 값에 따라 실제로 생성된 액세스 토큰, 리프레시 토큰 값)가 포함되어 분리하였습니다. Rest Docs Test에 대한 오류(data 객체가 null로 들어가는 현상)는 알려주신대로 Mock Resolver를 추가하여 해결하였습니다😃

<br>

## Test
<img width="441" alt="스크린샷 2024-01-06 오후 3 59 53" src="https://github.com/TF3-Project-PhotoSpot/photospot-be/assets/107015624/228badf8-e272-4951-b258-909aaca6fa9a">
