### PR TITLE
[FIX] aws credentials 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,3 +55,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+  cloud:
+    aws:
+      credentials:
+        instance-profile: true
+        access-key:
+        secret-key:


### PR DESCRIPTION
## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- default profile에 선언된 aws credentials access, secret key 환경 변수로 인해서 EC2 인스턴스의 IAM Role로 생성된 access, secret key가 적용이 되지 않아서 parameter store로 환경 변수를 읽어오지 못하고 있었습니다.

<img width="1366" alt="스크린샷 2024-01-29 오전 12 44 08" src="https://github.com/TF3-Project-PhotoSpot/photospot-be/assets/57752068/07954262-9c19-43c9-b13d-c6be09bc0bb5">

<img width="545" alt="image" src="https://github.com/TF3-Project-PhotoSpot/photospot-be/assets/57752068/aefd8ec9-978a-4dd7-b6ab-ff1147643de8">

<br>

- 별도로 생성한 S3Properties와 `io.awspring.cloud:spring-cloud-aws`에서 생성하는 CredentialsProperties의 prefix가`spring.cloud.aws.credentials`로 같습니다.

<img width="1603" alt="image" src="https://github.com/TF3-Project-PhotoSpot/photospot-be/assets/57752068/125c279d-5764-4a3d-ba6a-1cf9828181b7">

<br>

- 그래서 배포 환경에서는 EC2의 role을 사용하도록 로컬에서 사용하는 aws credentials access, secret key를 초기화 해줬습니다.


<img width="314" alt="image" src="https://github.com/TF3-Project-PhotoSpot/photospot-be/assets/57752068/ab4e7854-2252-48be-a6ee-9ae5ba1e4372">

<img width="398" alt="image" src="https://github.com/TF3-Project-PhotoSpot/photospot-be/assets/57752068/c163c6e7-c303-40c3-a9d7-f53c963d2611">



<br>

## 🙏🏻 To Reviewers


- https://jojoldu.tistory.com/300
- https://stackoverflow.com/questions/30571728/aws-instance-profile-doesnt-work-with-spring-cloud-aws

<br>