### PR TITLE
[Feat] 방명록 미리보기 목록 API

### DIFF
--- a/src/docs/asciidoc/api/post/post.adoc
+++ b/src/docs/asciidoc/api/post/post.adoc
@@ -1,3 +1,12 @@
+=== 방명록 미리보기 목록 조회
+
+'''
+
+include::{snippets}/post-controller-docs-test/get-post-previews/http-request.adoc[]
+include::{snippets}/post-controller-docs-test/get-post-previews/query-parameters.adoc[]
+include::{snippets}/post-controller-docs-test/get-post-previews/response-body.adoc[]
+include::{snippets}/post-controller-docs-test/get-post-previews/response-fields-data.adoc[]
+
 === 방명록 상세 목록 조회
 
 '''

--- a/src/main/java/com/tf4/photospot/photo/domain/Photo.java
+++ b/src/main/java/com/tf4/photospot/photo/domain/Photo.java
@@ -6,8 +6,10 @@ import org.locationtech.jts.geom.Point;
 
 import com.tf4.photospot.global.entity.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,11 +32,10 @@ public class Photo extends BaseEntity {
 
 	private LocalDate takenAt;
 
-	// Todo : nullable = false 설정 넣으면 spotServiceTest 오류 발생 => 수정할것
-	@Column(columnDefinition = "POINT SRID 4326")
+	@Column(columnDefinition = "POINT SRID 4326", nullable = false)
 	private Point coord;
 
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "bubble_id")
 	private Bubble bubble;
 

--- a/src/main/java/com/tf4/photospot/post/application/PostService.java
+++ b/src/main/java/com/tf4/photospot/post/application/PostService.java
@@ -11,8 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.tf4.photospot.global.dto.SlicePageDto;
 import com.tf4.photospot.post.application.request.PostListRequest;
-import com.tf4.photospot.post.application.request.PostUploadRequest;
+import com.tf4.photospot.post.application.request.PostPreviewListRequest;
 import com.tf4.photospot.post.application.response.PostDetailResponse;
+import com.tf4.photospot.post.application.response.PostPreviewResponse;
 import com.tf4.photospot.post.application.response.PostWithLikeStatus;
 import com.tf4.photospot.post.domain.Post;
 import com.tf4.photospot.post.domain.PostTag;
@@ -25,16 +26,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostService {
 	private final PostQueryRepository postQueryRepository;
-
-	@Transactional
-	public void upload(PostUploadRequest request) {
-		// 이미지 좌표-> 주소로 변환 (1)
-		// 주소로 다시 좌표 검색 (2)
-
-		// 스팟 생성 별개
-		// 스팟 조회 -> 없을 경우 -> 카카오 좌표 주소 변환 API (2번)
-		// 방명록 생성
-	}
 
 	public SlicePageDto<PostDetailResponse> getPosts(PostListRequest request) {
 		final Slice<PostWithLikeStatus> postResponses = postQueryRepository.findPostsWithLikeStatus(request);
@@ -49,16 +40,7 @@ public class PostService {
 		return SlicePageDto.wrap(postDetailResponses, postResponses.hasNext());
 	}
 
-	public SlicePageDto<PostDetailResponse> getPostPreviews(PostListRequest request) {
-		final Slice<PostWithLikeStatus> postResponses = postQueryRepository.findPostsWithLikeStatus(request);
-		final Map<Post, List<PostTag>> postTagGroup = postQueryRepository
-			.findPostTagsIn(postResponses.stream().map(PostWithLikeStatus::post).toList())
-			.stream()
-			.collect(Collectors.groupingBy(PostTag::getPost));
-		final List<PostDetailResponse> postDetailResponses = postResponses.stream()
-			.map(postResponse -> PostDetailResponse.of(postResponse,
-				postTagGroup.getOrDefault(postResponse.post(), Collections.emptyList())))
-			.toList();
-		return SlicePageDto.wrap(postDetailResponses, postResponses.hasNext());
+	public SlicePageDto<PostPreviewResponse> getPostPreviews(PostPreviewListRequest request) {
+		return SlicePageDto.wrap(postQueryRepository.findPostPreviews(request));
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/application/PostService.java
+++ b/src/main/java/com/tf4/photospot/post/application/PostService.java
@@ -48,4 +48,17 @@ public class PostService {
 			.toList();
 		return SlicePageDto.wrap(postDetailResponses, postResponses.hasNext());
 	}
+
+	public SlicePageDto<PostDetailResponse> getPostPreviews(PostListRequest request) {
+		final Slice<PostWithLikeStatus> postResponses = postQueryRepository.findPostsWithLikeStatus(request);
+		final Map<Post, List<PostTag>> postTagGroup = postQueryRepository
+			.findPostTagsIn(postResponses.stream().map(PostWithLikeStatus::post).toList())
+			.stream()
+			.collect(Collectors.groupingBy(PostTag::getPost));
+		final List<PostDetailResponse> postDetailResponses = postResponses.stream()
+			.map(postResponse -> PostDetailResponse.of(postResponse,
+				postTagGroup.getOrDefault(postResponse.post(), Collections.emptyList())))
+			.toList();
+		return SlicePageDto.wrap(postDetailResponses, postResponses.hasNext());
+	}
 }

--- a/src/main/java/com/tf4/photospot/post/application/request/PostPreviewListRequest.java
+++ b/src/main/java/com/tf4/photospot/post/application/request/PostPreviewListRequest.java
@@ -1,0 +1,32 @@
+package com.tf4.photospot.post.application.request;
+
+import java.util.Set;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.tf4.photospot.global.exception.ApiException;
+import com.tf4.photospot.global.exception.domain.CommonErrorCode;
+
+public record PostPreviewListRequest(
+	Long spotId,
+	Pageable pageable
+) {
+	private static final Set<String> sortableProperties = Set.of("id", "likeCount");
+
+	public PostPreviewListRequest {
+		if (containsInvalidOrder(pageable.getSort())) {
+			throw new ApiException(CommonErrorCode.CANNOT_SORTED_PROPERTY);
+		}
+	}
+
+	private boolean containsInvalidOrder(Sort sort) {
+		return sort.stream().anyMatch(order -> !sortableProperties.contains(order.getProperty()));
+	}
+
+	public static PostPreviewListRequest createLatestPostsRequest(Long spotId, int previewCount) {
+		return new PostPreviewListRequest(spotId,
+			PageRequest.of(0, previewCount, Sort.by(Sort.Direction.DESC, "id")));
+	}
+}

--- a/src/main/java/com/tf4/photospot/post/application/response/PostPreviewResponse.java
+++ b/src/main/java/com/tf4/photospot/post/application/response/PostPreviewResponse.java
@@ -1,8 +1,10 @@
 package com.tf4.photospot.post.application.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 
 public record PostPreviewResponse(
+	@JsonIgnore
 	Long spotId,
 	Long postId,
 	String photoUrl

--- a/src/main/java/com/tf4/photospot/post/domain/Post.java
+++ b/src/main/java/com/tf4/photospot/post/domain/Post.java
@@ -74,4 +74,10 @@ public class Post extends BaseEntity {
 		this.likeCount = likeCount;
 		this.isPrivate = isPrivate;
 	}
+
+	public void delete() {
+		if (deletedAt == null) {
+			deletedAt = LocalDateTime.now();
+		}
+	}
 }

--- a/src/main/java/com/tf4/photospot/post/domain/Post.java
+++ b/src/main/java/com/tf4/photospot/post/domain/Post.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.locationtech.jts.geom.Point;
-
 import com.tf4.photospot.global.entity.BaseEntity;
 import com.tf4.photospot.photo.domain.Photo;
 import com.tf4.photospot.spot.domain.Spot;
@@ -58,8 +56,6 @@ public class Post extends BaseEntity {
 	@OneToMany(mappedBy = "post")
 	private List<Mention> mentions = new ArrayList<>();
 
-	private Point coord;
-
 	private String detailAddress;
 
 	private Long likeCount;
@@ -69,12 +65,11 @@ public class Post extends BaseEntity {
 	private LocalDateTime deletedAt;
 
 	@Builder
-	public Post(User writer, Photo photo, Spot spot, Point coord, String detailAddress, Long likeCount,
+	public Post(User writer, Photo photo, Spot spot, String detailAddress, Long likeCount,
 		boolean isPrivate) {
 		this.writer = writer;
 		this.photo = photo;
 		this.spot = spot;
-		this.coord = coord;
 		this.detailAddress = detailAddress;
 		this.likeCount = likeCount;
 		this.isPrivate = isPrivate;

--- a/src/main/java/com/tf4/photospot/post/presentation/PostController.java
+++ b/src/main/java/com/tf4/photospot/post/presentation/PostController.java
@@ -47,4 +47,13 @@ public class PostController {
 	) {
 		return ApiResponse.success(postService.getPosts(new PostListRequest(spotId, userId, pageable)));
 	}
+
+	@GetMapping("/preview")
+	public ApiResponse<SlicePageDto<PostDetailResponse>> getPostPreviews(
+		@RequestParam(name = "spotId") Long spotId,
+		@AuthUserId Long userId,
+		@SortDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		return ApiResponse.success(postService.getPosts(new PostListRequest(spotId, userId, pageable)));
+	}
 }

--- a/src/main/java/com/tf4/photospot/post/presentation/PostController.java
+++ b/src/main/java/com/tf4/photospot/post/presentation/PostController.java
@@ -3,22 +3,19 @@ package com.tf4.photospot.post.presentation;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.tf4.photospot.global.argument.AuthUserId;
 import com.tf4.photospot.global.dto.ApiResponse;
 import com.tf4.photospot.global.dto.SlicePageDto;
 import com.tf4.photospot.post.application.PostService;
 import com.tf4.photospot.post.application.request.PostListRequest;
-import com.tf4.photospot.post.application.request.PostUploadRequest;
+import com.tf4.photospot.post.application.request.PostPreviewListRequest;
 import com.tf4.photospot.post.application.response.PostDetailResponse;
+import com.tf4.photospot.post.application.response.PostPreviewResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,18 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class PostController {
-
 	private final PostService postService;
-
-	@PostMapping()
-	public ResponseEntity<?> uploadPost(
-		@RequestPart("image") MultipartFile image
-		// @RequestBody UploadPostRequest request
-	) {
-		postService.upload(new PostUploadRequest());
-
-		return ResponseEntity.ok().build();
-	}
 
 	@GetMapping
 	public ApiResponse<SlicePageDto<PostDetailResponse>> getPostDetails(
@@ -49,11 +35,10 @@ public class PostController {
 	}
 
 	@GetMapping("/preview")
-	public ApiResponse<SlicePageDto<PostDetailResponse>> getPostPreviews(
+	public ApiResponse<SlicePageDto<PostPreviewResponse>> getPostPreviews(
 		@RequestParam(name = "spotId") Long spotId,
-		@AuthUserId Long userId,
 		@SortDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		return ApiResponse.success(postService.getPosts(new PostListRequest(spotId, userId, pageable)));
+		return ApiResponse.success(postService.getPostPreviews(new PostPreviewListRequest(spotId, pageable)));
 	}
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -469,6 +469,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_post_api">Post API</a>
 <ul class="sectlevel2">
+<li><a href="#_방명록_미리보기_목록_조회">방명록 미리보기 목록 조회</a></li>
 <li><a href="#_방명록_상세_목록_조회">방명록 상세 목록 조회</a></li>
 </ul>
 </li>
@@ -741,6 +742,34 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-top"><p class="tableblock">INVALID_ROLE</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않은 권한입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S3UploaderErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>EMPTY_FILE</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EMPTY_FILE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비어있는 파일입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S3UploaderErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>INVALID_PHOTO_EXTENSION</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INVALID_PHOTO_EXTENSION</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않은 이미지 확장자입니다</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">S3UploaderErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>UNEXPECTED_UPLOAD_FAIL</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">UNEXPECTED_UPLOAD_FAIL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">500</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">예상치 못한 오류로 업로드를 실패했습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SpotErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>INVALID_SPOT_ID</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INVALID_SPOT_ID</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않는 SPOT ID입니다.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1392,6 +1421,128 @@ Host: localhost:8080</code></pre>
 <h2 id="_post_api"><a class="link" href="#_post_api">Post API</a></h2>
 <div class="sectionbody">
 <div class="sect2">
+<h3 id="_방명록_미리보기_목록_조회"><a class="link" href="#_방명록_미리보기_목록_조회">방명록 미리보기 목록 조회</a></h3>
+<hr>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/posts/preview?spotId=1&amp;page=0&amp;size=10&amp;sort=id,desc&amp;sort=likeCount,desc HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_5"><a class="link" href="#_query_parameters_5">Query Parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Constraints</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spotId</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">lat(33.0 ~ 39.0), lon(124.0 ~ 132.0)로 입력해주세요.<br>
+좌표에 빈 값이 들어갈 수 없습니다.<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스팟 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0부터 시작<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지당 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id,desc</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id, likeCount<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 옵션</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "code" : "200",
+  "message" : "OK",
+  "data" : {
+    "content" : [ {
+      "postId" : 1,
+      "photoUrl" : "photoUrl"
+    } ],
+    "hasNext" : false
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">org.springframework.restdocs.snippet.Attributes$Attribute@75bdb6b5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">방명록 상세 목록 리스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">방명록 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].photoUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">방명록 photo url</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 방명록 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_방명록_상세_목록_조회"><a class="link" href="#_방명록_상세_목록_조회">방명록 상세 목록 조회</a></h3>
 <hr>
 <div class="listingblock">
@@ -1401,7 +1552,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_5"><a class="link" href="#_query_parameters_5">Query Parameters</a></h4>
+<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1482,7 +1633,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1502,7 +1653,7 @@ Host: localhost:8080</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">org.springframework.restdocs.snippet.Attributes$Attribute@21756418</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">org.springframework.restdocs.snippet.Attributes$Attribute@78a331b2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">방명록 상세 목록 리스트</p></td>
 </tr>
 <tr>
@@ -1608,7 +1759,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">Query Parameters</a></h4>
+<h4 id="_query_parameters_7"><a class="link" href="#_query_parameters_7">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1667,7 +1818,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
+<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
@@ -54,7 +54,7 @@ class PostServiceTest extends IntegrationTestSupport {
 		List<Post> posts = createList(() -> createPost(spot, writer), 15);
 		postRepository.saveAll(posts);
 		// 마지막에 추가된 포스트는 태그, 좋아요 정보를 가지고 있다.
-		Post lastPost = createPost(spot, writer, createPhoto("firstPhotoUrl"), createPoint());
+		Post lastPost = createPost(spot, writer, createPhoto("firstPhotoUrl"));
 		postRepository.save(lastPost);
 		List<Tag> tags = tagRepository.saveAll(createTags("tagA", "tagB", "tagC"));
 		postTagRepository.saveAll(createPostTags(spot, lastPost, tags));

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.Sort;
 
 import com.tf4.photospot.global.dto.SlicePageDto;
 import com.tf4.photospot.post.application.request.PostListRequest;
+import com.tf4.photospot.post.application.request.PostPreviewListRequest;
 import com.tf4.photospot.post.application.response.PostDetailResponse;
+import com.tf4.photospot.post.application.response.PostPreviewResponse;
 import com.tf4.photospot.post.domain.Post;
 import com.tf4.photospot.post.domain.PostLikeRepository;
 import com.tf4.photospot.post.domain.PostRepository;
@@ -40,6 +42,66 @@ class PostServiceTest extends IntegrationTestSupport {
 	private final PostLikeRepository postLikeRepository;
 	private final PostTagRepository postTagRepository;
 	private final TagRepository tagRepository;
+
+	@DisplayName("방명록 미리보기 목록 조회")
+	@TestFactory
+	Stream<DynamicTest> getPostPreviews() {
+		//given
+		Spot spot = createSpot();
+		User writer = createUser("작성자");
+		spotRepository.save(spot);
+		userRepository.save(writer);
+		// Dummy posts
+		List<Post> posts = createList(() -> createPost(spot, writer), 15);
+		postRepository.saveAll(posts);
+		// Common Request
+		var firstPageRequest = new PostPreviewListRequest(spot.getId(),
+			PageRequest.of(0, 10, Sort.by(Sort.Order.desc("id"))));
+
+		return Stream.of(
+			dynamicTest("슬라이스 페이징으로 조회한다.", () -> {
+				//given
+				var lastPageRequest = new PostPreviewListRequest(spot.getId(),
+					PageRequest.of(1, 10, Sort.by(Sort.Order.desc("id"))));
+				//when
+				SlicePageDto<PostPreviewResponse> firstResponse = postService.getPostPreviews(firstPageRequest);
+				SlicePageDto<PostPreviewResponse> lastResponse = postService.getPostPreviews(lastPageRequest);
+				//then
+				assertThat(firstResponse.hasNext()).isTrue();
+				assertThat(firstResponse.content().size()).isEqualTo(firstPageRequest.pageable().getPageSize());
+				assertThat(lastResponse.hasNext()).isFalse();
+				assertThat(lastResponse.content().size()).isLessThan(lastPageRequest.pageable().getPageSize());
+			}),
+			dynamicTest("좋아요순으로 조회할 수 있다.", () -> {
+				//given
+				var allPostRequest = new PostPreviewListRequest(spot.getId(),
+					PageRequest.of(0, 15, Sort.by(Sort.Order.desc("likeCount"))));
+				//when
+				SlicePageDto<PostPreviewResponse> response = postService.getPostPreviews(allPostRequest);
+				final List<Long> postIdsSortedLikeCountDesc = posts.stream()
+					.sorted(comparing(Post::getLikeCount).reversed())
+					.map(Post::getId)
+					.toList();
+				//then
+				assertThatList(response.content().stream().map(PostPreviewResponse::postId).toList())
+					.isEqualTo(postIdsSortedLikeCountDesc);
+			}),
+			dynamicTest("삭제 되었거나 비공개 방명록은 조회할 수 없다.", () -> {
+				//given
+				Post privatePost = createPost(spot, writer, true);
+				Post deletePost = createPost(spot, writer);
+				deletePost.delete();
+				postRepository.saveAll(List.of(privatePost, deletePost));
+
+				var latestPostRequest = new PostPreviewListRequest(spot.getId(),
+					PageRequest.of(0, 10, Sort.by(Sort.Order.desc("id"))));
+				//when
+				SlicePageDto<PostPreviewResponse> response = postService.getPostPreviews(latestPostRequest);
+				//then
+				assertThat(response.content().get(0).postId()).isNotIn(privatePost.getId(), deletePost.getId());
+			})
+		);
+	}
 
 	@DisplayName("방명록 상세 목록 조회")
 	@TestFactory

--- a/src/test/java/com/tf4/photospot/spot/application/SpotServiceTest.java
+++ b/src/test/java/com/tf4/photospot/spot/application/SpotServiceTest.java
@@ -94,7 +94,7 @@ class SpotServiceTest extends IntegrationTestSupport {
 			}),
 			dynamicTest("최신 방명록 미리보기를 조회한다.", () -> {
 				//given
-				List<Post> posts = createList(() -> createPost(spot, user, createPhoto("photoUrl"), createPoint()),
+				List<Post> posts = createList(() -> createPost(spot, user, createPhoto("photoUrl")),
 					5);
 				postRepository.saveAll(posts);
 				//when

--- a/src/test/java/com/tf4/photospot/spring/docs/common/CommonController.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/common/CommonController.java
@@ -19,6 +19,9 @@ import com.tf4.photospot.global.dto.ValidationError;
 import com.tf4.photospot.global.exception.domain.AuthErrorCode;
 import com.tf4.photospot.global.exception.domain.CommonErrorCode;
 import com.tf4.photospot.global.exception.domain.MapErrorCode;
+import com.tf4.photospot.global.exception.domain.S3UploaderErrorCode;
+import com.tf4.photospot.global.exception.domain.SpotErrorCode;
+import com.tf4.photospot.global.exception.domain.UserErrorCode;
 
 @RequestMapping("/common")
 @RestController
@@ -50,7 +53,10 @@ public class CommonController {
 		var errorCodeGroups = Stream.of(
 			CommonErrorCode.values(),
 			MapErrorCode.values(),
-			AuthErrorCode.values()
+			AuthErrorCode.values(),
+			S3UploaderErrorCode.values(),
+			SpotErrorCode.values(),
+			UserErrorCode.values()
 		);
 		return errorCodeGroups.flatMap(Arrays::stream)
 			.collect(Collectors.toMap(

--- a/src/test/java/com/tf4/photospot/support/TestFixture.java
+++ b/src/test/java/com/tf4/photospot/support/TestFixture.java
@@ -43,23 +43,22 @@ public class TestFixture {
 	}
 
 	public static Post createPost(Spot spot, User user, boolean isPrivate) {
-		return createPost(spot, user, createPhoto(), createPoint(), getRandomLikeCount(), isPrivate);
+		return createPost(spot, user, createPhoto(), getRandomLikeCount(), isPrivate);
 	}
 
 	public static Post createPost(Spot spot, User user, Long likeCount) {
-		return createPost(spot, user, createPhoto(), createPoint(), likeCount, false);
+		return createPost(spot, user, createPhoto(), likeCount, false);
 	}
 
-	public static Post createPost(Spot spot, User user, Photo photo, Point coord) {
-		return createPost(spot, user, photo, coord, getRandomLikeCount(), false);
+	public static Post createPost(Spot spot, User user, Photo photo) {
+		return createPost(spot, user, photo, getRandomLikeCount(), false);
 	}
 
-	public static Post createPost(Spot spot, User user, Photo photo, Point coord, Long likeCount, boolean isPrivate) {
+	public static Post createPost(Spot spot, User user, Photo photo, Long likeCount, boolean isPrivate) {
 		return Post.builder()
 			.spot(spot)
 			.writer(user)
 			.photo(photo)
-			.coord(coord)
 			.detailAddress("디테일 주소")
 			.likeCount(likeCount)
 			.isPrivate(isPrivate)
@@ -71,7 +70,10 @@ public class TestFixture {
 	}
 
 	public static Photo createPhoto(String photoUrl) {
-		return Photo.builder().photoUrl(photoUrl).build();
+		return Photo.builder()
+			.photoUrl(photoUrl)
+			.coord(createPoint())
+			.build();
 	}
 
 	public static Photo createPhoto() {

--- a/src/test/java/com/tf4/photospot/support/TestFixture.java
+++ b/src/test/java/com/tf4/photospot/support/TestFixture.java
@@ -77,7 +77,7 @@ public class TestFixture {
 	}
 
 	public static Photo createPhoto() {
-		return createPhoto(("photoUrl"));
+		return createPhoto("photoUrl");
 	}
 
 	public static User createUser(String nickname, String account, String providerType) {


### PR DESCRIPTION
## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 방명록 미리보기 목록 API 구현
- 기존의 Spot 상세 조회 시 최신 방명록 미리보기를 보여주던 기능과 합쳐서 리펙토링 했습니다.
- Enum 예외 클래스 추가해줬는데 예외 메시지를 도메인에 따라 나누다보니 Rest Docs에 직접 추가해줘야 하는 단점이 있네요
- 좌표를 방명록 -> 사진으로 수정했습니다.

<br>

## 🙏🏻 To Reviewers
