### PR TITLE
[Feat] 방명록 좋아요, 좋아요 취소 기능 추가

### DIFF
--- a/src/docs/asciidoc/api/post/post.adoc
+++ b/src/docs/asciidoc/api/post/post.adoc
@@ -32,3 +32,11 @@ include::{snippets}/post-controller-docs-test/upload-post/response-fields.adoc[]
 include::{snippets}/post-controller-docs-test/like-post/http-request.adoc[]
 include::{snippets}/post-controller-docs-test/like-post/response-body.adoc[]
 include::{snippets}/post-controller-docs-test/like-post/response-fields.adoc[]
+
+=== 방명록 좋아요 취소
+
+'''
+
+include::{snippets}/post-controller-docs-test/cancel-post-like/http-request.adoc[]
+include::{snippets}/post-controller-docs-test/cancel-post-like/response-body.adoc[]
+include::{snippets}/post-controller-docs-test/cancel-post-like/response-fields.adoc[]

--- a/src/docs/asciidoc/api/post/post.adoc
+++ b/src/docs/asciidoc/api/post/post.adoc
@@ -24,3 +24,11 @@ include::{snippets}/post-controller-docs-test/upload-post/http-request.adoc[]
 include::{snippets}/post-controller-docs-test/upload-post/request-fields.adoc[]
 include::{snippets}/post-controller-docs-test/upload-post/response-body.adoc[]
 include::{snippets}/post-controller-docs-test/upload-post/response-fields.adoc[]
+
+=== 방명록 좋아요
+
+'''
+
+include::{snippets}/post-controller-docs-test/like-post/http-request.adoc[]
+include::{snippets}/post-controller-docs-test/like-post/response-body.adoc[]
+include::{snippets}/post-controller-docs-test/like-post/response-fields.adoc[]

--- a/src/main/java/com/tf4/photospot/global/aop/Retry.java
+++ b/src/main/java/com/tf4/photospot/global/aop/Retry.java
@@ -1,0 +1,14 @@
+package com.tf4.photospot.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = ElementType.METHOD)
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface Retry {
+	int maxRetryCount() default 5;
+
+	int delayForMillis() default 200;
+}

--- a/src/main/java/com/tf4/photospot/global/aop/RetryAspect.java
+++ b/src/main/java/com/tf4/photospot/global/aop/RetryAspect.java
@@ -1,0 +1,35 @@
+package com.tf4.photospot.global.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+import com.tf4.photospot.global.exception.ApiException;
+import com.tf4.photospot.global.exception.domain.CommonErrorCode;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@Order(value = Ordered.LOWEST_PRECEDENCE - 1) // @Transaction 전 순서, 다른 aop가 추가 된다면 Order에 대한 고려
+public class RetryAspect {
+	@Around("@annotation(retry)")
+	public Object retry(ProceedingJoinPoint joinPoint, Retry retry) throws Throwable {
+		for (int retryCount = 0; retryCount <= retry.maxRetryCount(); retryCount++) {
+			try {
+				return joinPoint.proceed();
+			} catch (CannotAcquireLockException | OptimisticLockException | OptimisticLockingFailureException ex) {
+				log.error("[RETRY FAILED][{}/{}] {}", retryCount, retry.maxRetryCount(), ex.getClass().getName());
+			}
+			Thread.sleep(retry.delayForMillis()); // delay 방식은 상황에 따라 바뀔 수 있음
+		}
+		throw new ApiException(CommonErrorCode.FAILED_BECAUSE_OF_CONCURRENCY_UPDATE);
+	}
+}

--- a/src/main/java/com/tf4/photospot/global/exception/domain/CommonErrorCode.java
+++ b/src/main/java/com/tf4/photospot/global/exception/domain/CommonErrorCode.java
@@ -14,7 +14,8 @@ public enum CommonErrorCode implements ApiErrorCode {
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid Parameter"),
 	UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "unexpected error"),
 	CANNOT_SORTED_PROPERTY(HttpStatus.BAD_REQUEST, "정렬할 수 없는 property가 포함되어 있습니다."),
-	MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터를 추가해주세요.");
+	MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터를 추가해주세요."),
+	FAILED_BECAUSE_OF_CONCURRENCY_UPDATE(HttpStatus.INTERNAL_SERVER_ERROR, "동시에 많은 업데이트로 인해 실패했습니다.");
 
 	private final HttpStatusCode statusCode;
 	private final String message;

--- a/src/main/java/com/tf4/photospot/global/exception/domain/PostErrorCode.java
+++ b/src/main/java/com/tf4/photospot/global/exception/domain/PostErrorCode.java
@@ -13,7 +13,9 @@ import lombok.RequiredArgsConstructor;
 public enum PostErrorCode implements ApiErrorCode {
 	NOT_FOUND_TAG(HttpStatus.BAD_REQUEST, "존재하지 않은 태그입니다."),
 	NOT_FOUND_POST(HttpStatus.NOT_FOUND, "유효하지 않는 방명록입니다."),
-	ALREADY_LIKE(HttpStatus.BAD_REQUEST, "이미 해당 포스트를 좋아요 했습니다.");
+	ALREADY_LIKE(HttpStatus.BAD_REQUEST, "이미 해당 방명록을 좋아요 했습니다."),
+	NO_EXISTS_LIKE(HttpStatus.BAD_REQUEST, "해당 방명록 좋아요가 존재하지 않습니다."),
+	CAN_NOT_CANCEL_LIKE(HttpStatus.BAD_REQUEST, "해당 방명록 좋아요를 취소할 수 없습니다.");
 
 	private final HttpStatusCode statusCode;
 	private final String message;

--- a/src/main/java/com/tf4/photospot/global/exception/domain/PostErrorCode.java
+++ b/src/main/java/com/tf4/photospot/global/exception/domain/PostErrorCode.java
@@ -11,8 +11,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PostErrorCode implements ApiErrorCode {
-
-	NOT_FOUND_TAG(HttpStatus.BAD_REQUEST, "존재하지 않은 태그입니다.");
+	NOT_FOUND_TAG(HttpStatus.BAD_REQUEST, "존재하지 않은 태그입니다."),
+	NOT_FOUND_POST(HttpStatus.NOT_FOUND, "유효하지 않는 방명록입니다."),
+	ALREADY_LIKE(HttpStatus.BAD_REQUEST, "이미 해당 포스트를 좋아요 했습니다.");
 
 	private final HttpStatusCode statusCode;
 	private final String message;

--- a/src/main/java/com/tf4/photospot/post/application/PostService.java
+++ b/src/main/java/com/tf4/photospot/post/application/PostService.java
@@ -143,14 +143,10 @@ public class PostService {
 
 	@Retry
 	@Transactional
-	public void canclePostLike(Long postId, Long userId) {
-		final User user = userRepository.findById(userId)
-			.orElseThrow(() -> new ApiException(UserErrorCode.NOT_FOUND_USER));
-		final Post post = postRepository.findById(postId)
-			.orElseThrow(() -> new ApiException(PostErrorCode.NOT_FOUND_POST));
-		final PostLike postLike = postQueryRepository.findPostLike(post, user)
+	public void cancelPostLike(Long postId, Long userId) {
+		final PostLike postLike = postQueryRepository.findPostLikeFetch(postId, userId)
 			.orElseThrow(() -> new ApiException(PostErrorCode.NO_EXISTS_LIKE));
-		post.cancelLike(postLike);
+		postLike.cancel();
 		postLikeRepository.delete(postLike);
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/application/PostService.java
+++ b/src/main/java/com/tf4/photospot/post/application/PostService.java
@@ -140,4 +140,17 @@ public class PostService {
 		final PostLike postLike = post.likeFrom(user);
 		postLikeRepository.save(postLike);
 	}
+
+	@Retry
+	@Transactional
+	public void canclePostLike(Long postId, Long userId) {
+		final User user = userRepository.findById(userId)
+			.orElseThrow(() -> new ApiException(UserErrorCode.NOT_FOUND_USER));
+		final Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new ApiException(PostErrorCode.NOT_FOUND_POST));
+		final PostLike postLike = postQueryRepository.findPostLike(post, user)
+			.orElseThrow(() -> new ApiException(PostErrorCode.NO_EXISTS_LIKE));
+		post.cancelLike(postLike);
+		postLikeRepository.delete(postLike);
+	}
 }

--- a/src/main/java/com/tf4/photospot/post/domain/Post.java
+++ b/src/main/java/com/tf4/photospot/post/domain/Post.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.tf4.photospot.global.entity.BaseEntity;
+import com.tf4.photospot.global.exception.ApiException;
+import com.tf4.photospot.global.exception.domain.PostErrorCode;
 import com.tf4.photospot.photo.domain.Photo;
 import com.tf4.photospot.spot.domain.Spot;
 import com.tf4.photospot.user.domain.User;
@@ -86,7 +88,14 @@ public class Post extends BaseEntity {
 	}
 
 	public PostLike likeFrom(User user) {
-		likeCount += 1;
+		likeCount++;
 		return new PostLike(this, user);
+	}
+
+	public void cancelLike(PostLike postLike) {
+		if (this != postLike.getPost() || likeCount == 0L) {
+			throw new ApiException(PostErrorCode.CAN_NOT_CANCEL_LIKE);
+		}
+		likeCount--;
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/domain/Post.java
+++ b/src/main/java/com/tf4/photospot/post/domain/Post.java
@@ -21,6 +21,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,6 +65,9 @@ public class Post extends BaseEntity {
 
 	private LocalDateTime deletedAt;
 
+	@Version
+	private Integer version;
+
 	@Builder
 	public Post(User writer, Photo photo, Spot spot, String detailAddress, Long likeCount,
 		boolean isPrivate) {
@@ -81,11 +85,8 @@ public class Post extends BaseEntity {
 		}
 	}
 
-	public void addPostTags(List<PostTag> postTags) {
-		this.postTags.addAll(postTags);
-	}
-
-	public void addMentions(List<Mention> mentions) {
-		this.mentions.addAll(mentions);
+	public PostLike likeFrom(User user) {
+		likeCount += 1;
+		return new PostLike(this, user);
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/domain/PostLike.java
+++ b/src/main/java/com/tf4/photospot/post/domain/PostLike.java
@@ -7,13 +7,20 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@Table(
+	indexes = @Index(name = "post_like_unique_idx", columnList = "post_id, user_id", unique = true)
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostLike extends BaseEntity {
 	@Id

--- a/src/main/java/com/tf4/photospot/post/domain/PostLike.java
+++ b/src/main/java/com/tf4/photospot/post/domain/PostLike.java
@@ -40,4 +40,8 @@ public class PostLike extends BaseEntity {
 		this.post = post;
 		this.user = user;
 	}
+
+	public void cancel() {
+		post.cancelLike(this);
+	}
 }

--- a/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
@@ -7,6 +7,7 @@ import static com.tf4.photospot.post.domain.QPostLike.*;
 import static com.tf4.photospot.post.domain.QPostTag.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,6 +24,7 @@ import com.tf4.photospot.post.application.response.PostWithLikeStatus;
 import com.tf4.photospot.post.application.response.QPostPreviewResponse;
 import com.tf4.photospot.post.application.response.QPostWithLikeStatus;
 import com.tf4.photospot.post.domain.Post;
+import com.tf4.photospot.post.domain.PostLike;
 import com.tf4.photospot.post.domain.PostTag;
 import com.tf4.photospot.user.domain.QUser;
 import com.tf4.photospot.user.domain.User;
@@ -90,5 +92,11 @@ public class PostQueryRepository {
 			.where(postLike.post.eq(post).and(postLike.user.eq(user)))
 			.fetchFirst();
 		return exists != null;
+	}
+
+	public Optional<PostLike> findPostLike(Post post, User user) {
+		return Optional.ofNullable(queryFactory.selectFrom(postLike)
+			.where(postLike.post.eq(post).and(postLike.user.eq(user)))
+			.fetchOne());
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
@@ -25,6 +25,7 @@ import com.tf4.photospot.post.application.response.QPostWithLikeStatus;
 import com.tf4.photospot.post.domain.Post;
 import com.tf4.photospot.post.domain.PostTag;
 import com.tf4.photospot.user.domain.QUser;
+import com.tf4.photospot.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -81,5 +82,13 @@ public class PostQueryRepository {
 
 	private BooleanExpression canVisble() {
 		return post.isPrivate.isFalse().and(post.deletedAt.isNull());
+	}
+
+	public boolean existsPostLike(Post post, User user) {
+		final Integer exists = queryFactory.selectOne()
+			.from(postLike)
+			.where(postLike.post.eq(post).and(postLike.user.eq(user)))
+			.fetchFirst();
+		return exists != null;
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
@@ -94,9 +94,10 @@ public class PostQueryRepository {
 		return exists != null;
 	}
 
-	public Optional<PostLike> findPostLike(Post post, User user) {
+	public Optional<PostLike> findPostLikeFetch(Long postId, Long userId) {
 		return Optional.ofNullable(queryFactory.selectFrom(postLike)
-			.where(postLike.post.eq(post).and(postLike.user.eq(user)))
+			.join(postLike.post, post).fetchJoin()
+			.where(postLike.post.id.eq(postId).and(postLike.user.id.eq(userId)))
 			.fetchOne());
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/presentation/PostController.java
+++ b/src/main/java/com/tf4/photospot/post/presentation/PostController.java
@@ -6,11 +6,13 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tf4.photospot.global.argument.AuthUserId;
+import com.tf4.photospot.global.dto.ApiResponse;
 import com.tf4.photospot.global.dto.SlicePageDto;
 import com.tf4.photospot.post.application.PostService;
 import com.tf4.photospot.post.application.request.PostListRequest;
@@ -28,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class PostController {
-
 	private final PostService postService;
 
 	@GetMapping
@@ -51,5 +52,14 @@ public class PostController {
 	@PostMapping
 	public PostUploadResponse uploadPost(@AuthUserId Long userId, @RequestBody @Valid PostUploadHttpRequest request) {
 		return postService.upload(PostUploadRequest.of(userId, request));
+	}
+
+	@PostMapping("{postId}/likes")
+	public ApiResponse likePost(
+		@PathVariable(name = "postId") Long postId,
+		@AuthUserId Long userId
+	) {
+		postService.likePost(postId, userId);
+		return ApiResponse.SUCCESS;
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/presentation/PostController.java
+++ b/src/main/java/com/tf4/photospot/post/presentation/PostController.java
@@ -3,10 +3,11 @@ package com.tf4.photospot.post.presentation;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,6 +57,15 @@ public class PostController {
 
 	@PostMapping("{postId}/likes")
 	public ApiResponse likePost(
+		@PathVariable(name = "postId") Long postId,
+		@AuthUserId Long userId
+	) {
+		postService.likePost(postId, userId);
+		return ApiResponse.SUCCESS;
+	}
+
+	@DeleteMapping("{postId}/likes")
+	public ApiResponse cancelPostLike(
 		@PathVariable(name = "postId") Long postId,
 		@AuthUserId Long userId
 	) {

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -473,6 +473,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_방명록_미리보기_목록_조회">방명록 미리보기 목록 조회</a></li>
 <li><a href="#_방명록_상세_목록_조회">방명록 상세 목록 조회</a></li>
 <li><a href="#_방명록_등록">방명록 등록</a></li>
+<li><a href="#_방명록_좋아요">방명록 좋아요</a></li>
 </ul>
 </li>
 <li><a href="#_map_api">Map API</a>
@@ -653,6 +654,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-top"><p class="tableblock">MISSING_REQUEST_PARAMETER</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">요청 파라미터를 추가해주세요.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">CommonErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FAILED_BECAUSE_OF_CONCURRENCY_UPDATE</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FAILED_BECAUSE_OF_CONCURRENCY_UPDATE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">500</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동시에 많은 업데이트로 인해 실패했습니다.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">MapErrorCode</p></td>
@@ -1973,6 +1981,51 @@ Host: localhost:8080
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_방명록_좋아요"><a class="link" href="#_방명록_좋아요">방명록 좋아요</a></h3>
+<hr>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/posts/1/likes HTTP/1.1
+Host: localhost:8080
+Content-Type: application/x-www-form-urlencoded</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "message" : "성공"
+}</code></pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -2043,7 +2096,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
+<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2106,7 +2159,7 @@ Host: localhost:8080</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-31 16:11:23 +0900
+Last updated 2024-01-29 00:53:38 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceLockingTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceLockingTest.java
@@ -115,7 +115,7 @@ class PostServiceLockingTest {
 				final CountDownLatch completeLatch = new CountDownLatch(postLikeCount);
 				//when
 				users.forEach(user -> executorService.submit(() -> {
-					postService.canclePostLike(post.getId(), user.getId());
+					postService.cancelPostLike(post.getId(), user.getId());
 					completeLatch.countDown();
 				}));
 				completeLatch.await();
@@ -130,7 +130,7 @@ class PostServiceLockingTest {
 				//when
 				var likeWorker = CompletableFuture.runAsync(() -> postService.likePost(post.getId(), user.getId()));
 				var likeCancelWorker = CompletableFuture.runAsync(
-					() -> postService.canclePostLike(post.getId(), user.getId()));
+					() -> postService.cancelPostLike(post.getId(), user.getId()));
 				//then
 				assertThatThrownBy(likeCancelWorker::join)
 					.extracting(Throwable::getCause)

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceLockingTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceLockingTest.java
@@ -1,0 +1,140 @@
+package com.tf4.photospot.post.application;
+
+import static com.tf4.photospot.support.TestFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.tf4.photospot.global.exception.ApiException;
+import com.tf4.photospot.global.exception.domain.CommonErrorCode;
+import com.tf4.photospot.post.domain.Post;
+import com.tf4.photospot.post.domain.PostLike;
+import com.tf4.photospot.post.domain.PostLikeRepository;
+import com.tf4.photospot.post.domain.PostRepository;
+import com.tf4.photospot.spot.domain.Spot;
+import com.tf4.photospot.spot.domain.SpotRepository;
+import com.tf4.photospot.user.domain.User;
+import com.tf4.photospot.user.domain.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+@RequiredArgsConstructor
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class PostServiceLockingTest {
+	private final PostService postService;
+	private final PostRepository postRepository;
+	private final SpotRepository spotRepository;
+	private final UserRepository userRepository;
+	private final PostLikeRepository postLikeRepository;
+	private final TransactionTemplate transactionTemplate;
+
+	@AfterEach
+	void tearDown() {
+		postLikeRepository.deleteAll();
+		postRepository.deleteAll();
+		spotRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@DisplayName("비슷한 타이밍에 방명록 좋아요를 누르면 낙관적 락 예외가 발생한다.")
+	@Test
+	void postLikeOptimisticLockExceptionTest() {
+		//given
+		final Spot spot = spotRepository.save(createSpot());
+		final User writer = userRepository.save(createUser("이성빈"));
+		final Post post = postRepository.save(createPost(spot, writer, 0L));
+		final User likeFailUser = userRepository.save(createUser("userA"));
+		final User likeSuccessUser = userRepository.save(createUser("userB"));
+		var beforeVersion = post.getVersion();
+		var beforeLikeCount = post.getLikeCount();
+		var waitingLatch = new CountDownLatch(1);
+		//when
+		// 낙관적 락 version이 업데이트가 될때까지 대기
+		var waitWorker = CompletableFuture.runAsync(() -> likePostWaitWithNoRetry(post, likeFailUser, waitingLatch));
+		sleep(200L);
+		// 낙관적 락 version을 업데이트하고 countDown
+		CompletableFuture.runAsync(() -> postService.likePost(post.getId(), likeSuccessUser.getId()))
+			.thenRun(waitingLatch::countDown);
+		// then
+		// 두번째 작업의 완료로 인해 version이 변경 되어 OptimisticLockingFailureException 예외 발생
+		waitWorker.exceptionally(ex -> {
+			assertThat(ex.getCause()).isInstanceOf(OptimisticLockingFailureException.class);
+			return null;
+		}).join();
+		assertThat(postRepository.findById(post.getId())).isPresent().get()
+			.extracting("version", "likeCount")
+			.containsExactly(beforeVersion + 1, beforeLikeCount + 1L);
+	}
+
+	@DisplayName("여러 유저가 특정 방명록의 좋아요를 동시에 누르면 retry가 발생한다.")
+	@Test
+	void postLikeLockTest() throws InterruptedException {
+		//given
+		final int postLikeCount = 5;
+		final Spot spot = spotRepository.save(createSpot());
+		final User writer = userRepository.save(createUser("이성빈"));
+		final Post post = postRepository.save(createPost(spot, writer, 0L));
+		final List<User> postLikeUsers = userRepository.saveAll(createList(() -> createUser("user"), postLikeCount));
+		final ExecutorService executorService = Executors.newFixedThreadPool(postLikeCount);
+		final CountDownLatch completeLatch = new CountDownLatch(postLikeCount);
+		var expectPostLikeSuccessCount = new AtomicLong(postLikeCount);
+		//when
+		postLikeUsers.forEach(user -> executorService.submit(() -> {
+			try {
+				postService.likePost(post.getId(), user.getId());
+			} catch (Exception ex) {
+				assertThat(ex).isInstanceOf(ApiException.class)
+					.extracting("errorCode")
+					.isEqualTo(CommonErrorCode.FAILED_BECAUSE_OF_CONCURRENCY_UPDATE);
+				expectPostLikeSuccessCount.decrementAndGet();
+			}
+			completeLatch.countDown();
+		}));
+		completeLatch.await();
+
+		//then
+		assertThat(postRepository.findById(post.getId())).isPresent().get()
+			.extracting("likeCount")
+			.isEqualTo(expectPostLikeSuccessCount.get());
+	}
+
+	void likePostWaitWithNoRetry(Post post, User user, CountDownLatch waitingLatch) {
+		transactionTemplate.executeWithoutResult(status -> {
+			PostLike postLike = post.likeFrom(user);
+			wait(waitingLatch);
+			postLikeRepository.save(postLike);
+		});
+	}
+
+	private static void wait(CountDownLatch waitingLatch) {
+		try {
+			waitingLatch.await();
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void sleep(Long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
@@ -57,6 +57,25 @@ class PostServiceTest extends IntegrationTestSupport {
 	private final PostTagRepository postTagRepository;
 	private final TagRepository tagRepository;
 
+	@DisplayName("방명록 좋아요")
+	@TestFactory
+	Stream<DynamicTest> likePost() {
+		//given
+		final Spot spot = spotRepository.save(createSpot());
+		final User writer = userRepository.save(createUser("이성빈"));
+		final Post post = postRepository.save(createPost(spot, writer, 0L));
+		final User user = userRepository.save(createUser("user"));
+
+		return Stream.of(
+			dynamicTest("좋아요를 누를 수 있다.", () ->
+				assertThatNoException().isThrownBy(() -> postService.likePost(post.getId(), user.getId()))),
+			dynamicTest("좋아요를 중복해서 누를 수 없다.", () ->
+				assertThatThrownBy(() -> postService.likePost(post.getId(), user.getId()))
+					.isInstanceOf(ApiException.class)
+					.extracting("errorCode")
+					.isEqualTo(PostErrorCode.ALREADY_LIKE)));
+	}
+
 	@DisplayName("방명록 미리보기 목록 조회")
 	@TestFactory
 	Stream<DynamicTest> getPostPreviews() {

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
@@ -86,13 +86,13 @@ class PostServiceTest extends IntegrationTestSupport {
 				//given
 				final Long beforeLikes = post.getLikeCount();
 				//when
-				postService.canclePostLike(post.getId(), user.getId());
+				postService.cancelPostLike(post.getId(), user.getId());
 				//then
 				assertThat(postRepository.findById(post.getId())).isPresent().get()
 					.satisfies(updatedPost -> assertThat(updatedPost.getLikeCount()).isEqualTo(beforeLikes - 1));
 			}),
 			dynamicTest("좋아요 취소를 중복해서 할 수 없다.", () ->
-				assertThatThrownBy(() -> postService.canclePostLike(post.getId(), user.getId()))
+				assertThatThrownBy(() -> postService.cancelPostLike(post.getId(), user.getId()))
 					.isInstanceOf(ApiException.class)
 					.extracting("errorCode")
 					.isEqualTo(PostErrorCode.NO_EXISTS_LIKE)

--- a/src/test/java/com/tf4/photospot/post/domain/PostTest.java
+++ b/src/test/java/com/tf4/photospot/post/domain/PostTest.java
@@ -3,12 +3,18 @@ package com.tf4.photospot.post.domain;
 import static com.tf4.photospot.support.TestFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.DynamicTest.*;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
+import com.tf4.photospot.global.exception.ApiException;
+import com.tf4.photospot.global.exception.domain.PostErrorCode;
 import com.tf4.photospot.photo.domain.Photo;
 import com.tf4.photospot.spot.domain.Spot;
 import com.tf4.photospot.user.domain.User;
@@ -36,16 +42,39 @@ public class PostTest {
 	}
 
 	@Test
-	void addPostTags() {
-		List<PostTag> postTags = createPostTags(spot, post, tags);
-		post.addPostTags(postTags);
-		assertThat(post.getPostTags()).containsExactlyInAnyOrderElementsOf(postTags);
+	void likeFromTest() {
+		//when
+		final Long beforeLikeCount = post.getLikeCount();
+		final PostLike postLike = post.likeFrom(users.get(0));
+		//then
+		assertThat(postLike.getPost()).isEqualTo(post);
+		assertThat(post.getLikeCount()).isEqualTo(beforeLikeCount + 1);
 	}
 
-	@Test
-	void addMentions() {
-		List<Mention> mentions = createMentions(post, users);
-		post.addMentions(mentions);
-		assertThat(post.getMentions()).containsExactlyInAnyOrderElementsOf(mentions);
+	@TestFactory
+	Stream<DynamicTest> cancelLike() {
+		//given
+		return Stream.of(
+			dynamicTest("좋아요를 취소한다.", () -> {
+				final PostLike postLike = post.likeFrom(users.get(0));
+				post.cancelLike(postLike);
+				assertThat(post.getLikeCount()).isZero();
+			}),
+			dynamicTest("다른 방명록의 좋아요는 취소할 수 없다.", () -> {
+				final Post otherPost = createPost(spot, users.get(0));
+				final PostLike otherPostLike = createPostLike(otherPost, users.get(0));
+				assertThatThrownBy(() -> post.cancelLike(otherPostLike))
+					.isInstanceOf(ApiException.class)
+					.extracting("errorCode")
+					.isEqualTo(PostErrorCode.CAN_NOT_CANCEL_LIKE);
+			}),
+			dynamicTest("좋아요 개수는 0보다 줄어들 수 없다.", () -> {
+				final Post otherPost = createPost(spot, users.get(0));
+				final PostLike unsavedPostLike = createPostLike(otherPost, users.get(0));
+				assertThatThrownBy(() -> post.cancelLike(unsavedPostLike))
+					.isInstanceOf(ApiException.class)
+					.extracting("errorCode")
+					.isEqualTo(PostErrorCode.CAN_NOT_CANCEL_LIKE);
+			}));
 	}
 }

--- a/src/test/java/com/tf4/photospot/spring/docs/RestDocsSupport.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/RestDocsSupport.java
@@ -2,6 +2,7 @@ package com.tf4.photospot.spring.docs;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.snippet.Attributes.*;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -56,6 +58,11 @@ public abstract class RestDocsSupport {
 			preprocessRequest(prettyPrint()),
 			preprocessResponse(prettyPrint()),
 			snipets);
+	}
+
+	protected RestDocumentationResultHandler restDocsTemplateDefaultSuccess() {
+		return restDocsTemplate(responseFields(
+			fieldWithPath("message").type(JsonFieldType.STRING).description("성공")));
 	}
 
 	protected <T> Attribute defaultValue(T value) {

--- a/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
@@ -186,7 +186,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 	@Test
 	void cancelPostLike() throws Exception {
 		//given
-		willDoNothing().given(postService).canclePostLike(anyLong(), anyLong());
+		willDoNothing().given(postService).cancelPostLike(anyLong(), anyLong());
 		//when
 		mockMvc.perform(delete("/api/v1/posts/{postId}/likes", 1L))
 			.andExpect(status().isOk())

--- a/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
@@ -182,4 +182,14 @@ public class PostControllerDocsTest extends RestDocsSupport {
 			.andExpect(status().isOk())
 			.andDo(restDocsTemplateDefaultSuccess());
 	}
+
+	@Test
+	void cancelPostLike() throws Exception {
+		//given
+		willDoNothing().given(postService).canclePostLike(anyLong(), anyLong());
+		//when
+		mockMvc.perform(delete("/api/v1/posts/{postId}/likes", 1L))
+			.andExpect(status().isOk())
+			.andDo(restDocsTemplateDefaultSuccess());
+	}
 }

--- a/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
@@ -172,4 +172,14 @@ public class PostControllerDocsTest extends RestDocsSupport {
 				)
 			));
 	}
+
+	@Test
+	void likePost() throws Exception {
+		//given
+		willDoNothing().given(postService).likePost(anyLong(), anyLong());
+		//when
+		mockMvc.perform(post("/api/v1/posts/{postId}/likes", 1L))
+			.andExpect(status().isOk())
+			.andDo(restDocsTemplateDefaultSuccess());
+	}
 }

--- a/src/test/java/com/tf4/photospot/support/TestFixture.java
+++ b/src/test/java/com/tf4/photospot/support/TestFixture.java
@@ -48,11 +48,11 @@ public class TestFixture {
 	}
 
 	public static Post createPost(Spot spot, User user) {
-		return createPost(spot, user, getRandomLikeCount());
+		return createPost(spot, user, 0L);
 	}
 
 	public static Post createPost(Spot spot, User user, boolean isPrivate) {
-		return createPost(spot, user, createPhoto(), getRandomLikeCount(), isPrivate);
+		return createPost(spot, user, createPhoto(), 0L, isPrivate);
 	}
 
 	public static Post createPost(Spot spot, User user, Long likeCount) {
@@ -60,7 +60,7 @@ public class TestFixture {
 	}
 
 	public static Post createPost(Spot spot, User user, Photo photo) {
-		return createPost(spot, user, photo, getRandomLikeCount(), false);
+		return createPost(spot, user, photo, 0L, false);
 	}
 
 	public static Post createPost(Spot spot, User user, Photo photo, Long likeCount, boolean isPrivate) {
@@ -74,7 +74,7 @@ public class TestFixture {
 			.build();
 	}
 
-	private static long getRandomLikeCount() {
+	public static long createRandomLikeCount() {
 		return RANDOM.nextInt(LIKE_COUNT_RANGE);
 	}
 

--- a/src/test/java/com/tf4/photospot/support/TestFixture.java
+++ b/src/test/java/com/tf4/photospot/support/TestFixture.java
@@ -37,7 +37,7 @@ public class TestFixture {
 	}
 
 	public static Spot createSpot() {
-		return createSpot("주소", createPoint(), getRandomLikeCount());
+		return createSpot("주소", createPoint(), 0L);
 	}
 
 	public static Spot createSpot(CoordinateDto coord) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,6 +7,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        defer-datasource-initialization: true
+        use_sql_comments: true
+        format_sql: true
+    open-in-view: false
   cloud:
     aws:
       credentials:
@@ -15,6 +21,11 @@ spring:
       s3:
         region: ap-northeast-2
         bucket: bucket
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 kakao:
   rest-api-key: test6d177caw1120g3510952427y92d3


### PR DESCRIPTION
## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 방명록 좋아요, 좋아요 취소 기능 추가
- 방명록 좋아요 개수 업데이트시 동시성 문제로 낙관적 락과 재시도 aop 기능을 추가했습니다.
- 동시성 문제가 발생하는 경우가 드물 것으로 예상하고 낙관적 락을 사용했습니다.
- 테스트 코드 동작시 SQL 로그가 나오도록 수정했습니다.

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

**[참고 링크]**
- https://junhyunny.github.io/java/spring-boot/query-dsl/jpa/optimistic-lock-in-query-dsl/
- https://velog.io/@xogml951/API%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0-%EA%B8%B0%EB%A1%9D-Optimistic-Lock%EA%B3%BC-AOP%ED%99%9C%EC%9A%A9