### PR TITLE
[Feat] 스팟 조회시 방명록 태그 통계 기능

### DIFF
--- a/src/main/java/com/tf4/photospot/spot/application/SpotService.java
+++ b/src/main/java/com/tf4/photospot/spot/application/SpotService.java
@@ -14,6 +14,7 @@ import com.tf4.photospot.post.infrastructure.PostJdbcRepository;
 import com.tf4.photospot.post.infrastructure.PostQueryRepository;
 import com.tf4.photospot.spot.application.request.NearbySpotRequest;
 import com.tf4.photospot.spot.application.request.RecommendedSpotsRequest;
+import com.tf4.photospot.spot.application.response.MostPostTagRank;
 import com.tf4.photospot.spot.application.response.NearbySpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotListResponse;
 import com.tf4.photospot.spot.application.response.SpotCoordResponse;
@@ -52,12 +53,14 @@ public class SpotService {
 		return new NearbySpotListResponse(spotQueryRepository.findNearbySpots(request.coord(), request.radius()));
 	}
 
-	public SpotResponse findSpot(PostSearchCondition searchCond) {
+	public SpotResponse findSpot(PostSearchCondition searchCond, int mostPostTagCount) {
 		final Spot spot = spotRepository.findById(searchCond.spotId())
 			.orElseThrow(() -> new ApiException(SpotErrorCode.INVALID_SPOT_ID));
 		final Boolean bookmarked = spotQueryRepository.existsBookmark(spot.getId(), searchCond.userId());
 		final Slice<PostPreviewResponse> postPreviews = postQueryRepository.findPostPreviews(searchCond);
-		return SpotResponse.of(spot, bookmarked, postPreviews.getContent());
+		final List<MostPostTagRank> mostPostTagRanks = postJdbcRepository.findMostPostTagsOfSpot(spot,
+			mostPostTagCount);
+		return SpotResponse.of(spot, bookmarked, mostPostTagRanks, postPreviews.getContent());
 	}
 
 	public List<SpotCoordResponse> findSpotsOfMyPosts(Long userId) {

--- a/src/main/java/com/tf4/photospot/spot/application/response/MostPostTagRank.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/MostPostTagRank.java
@@ -1,0 +1,14 @@
+package com.tf4.photospot.spot.application.response;
+
+import lombok.Builder;
+
+public record MostPostTagRank(
+	Long id,
+	int count,
+	String name,
+	String iconUrl
+) {
+	@Builder
+	public MostPostTagRank {
+	}
+}

--- a/src/main/java/com/tf4/photospot/spot/application/response/SpotResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/SpotResponse.java
@@ -15,7 +15,7 @@ public record SpotResponse(
 	Point coord,
 	Long postCount,
 	Boolean bookmarked,
-	List<MostPostTagRank> postTagCounts,
+	List<MostPostTagRank> mostPostTagRanks,
 	List<PostPreviewResponse> previewResponses
 ) {
 	@Builder

--- a/src/main/java/com/tf4/photospot/spot/application/response/SpotResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/SpotResponse.java
@@ -14,8 +14,9 @@ public record SpotResponse(
 	String address,
 	Point coord,
 	Long postCount,
-	List<PostPreviewResponse> previewResponses,
-	Boolean bookmarked
+	Boolean bookmarked,
+	List<MostPostTagRank> postTagCounts,
+	List<PostPreviewResponse> previewResponses
 ) {
 	@Builder
 	public SpotResponse {
@@ -24,14 +25,16 @@ public record SpotResponse(
 		}
 	}
 
-	public static SpotResponse of(Spot spot, Boolean bookmarked, List<PostPreviewResponse> previewResponses) {
+	public static SpotResponse of(Spot spot, Boolean bookmarked, List<MostPostTagRank> mostPostTagRanks,
+		List<PostPreviewResponse> previewResponses) {
 		return new SpotResponse(
 			spot.getId(),
 			spot.getAddress(),
 			spot.getCoord(),
 			spot.getPostCount(),
-			previewResponses,
-			bookmarked
+			bookmarked,
+			mostPostTagRanks,
+			previewResponses
 		);
 	}
 }

--- a/src/main/java/com/tf4/photospot/spot/presentation/SpotController.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/SpotController.java
@@ -25,6 +25,7 @@ import com.tf4.photospot.spot.application.request.RecommendedSpotsRequest;
 import com.tf4.photospot.spot.application.response.NearbySpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotListResponse;
 import com.tf4.photospot.spot.application.response.SpotResponse;
+import com.tf4.photospot.spot.presentation.request.FindSpotHttpRequest;
 import com.tf4.photospot.spot.presentation.response.RecommendedSpotHttpResponse;
 import com.tf4.photospot.spot.presentation.response.RecommendedSpotListHttpResponse;
 import com.tf4.photospot.spot.presentation.response.SpotHttpResponse;
@@ -75,9 +76,7 @@ public class SpotController {
 	public SpotHttpResponse getSpot(
 		@PathVariable(name = "spotId") Long spotId,
 		@ModelAttribute @Valid CoordinateDto startingCoord,
-		@RequestParam(name = "postPreviewCount", defaultValue = "5")
-		@Range(min = 1, max = 10, message = "미리보기 사진은 1~10개만 가능합니다.") Integer postPreviewCount,
-		@RequestParam(name = "distance", defaultValue = "true") Boolean requireDistance,
+		@ModelAttribute @Valid FindSpotHttpRequest request,
 		@AuthUserId Long userId
 	) {
 		Integer distance = 0;
@@ -85,11 +84,11 @@ public class SpotController {
 		PostSearchCondition postSearchCond = PostSearchCondition.builder()
 			.spotId(spotId)
 			.userId(userId)
-			.pageable(PageRequest.of(0, postPreviewCount, sortByLatest))
+			.pageable(PageRequest.of(0, request.postPreviewCount(), sortByLatest))
 			.type(PostSearchType.POSTS_OF_SPOT)
 			.build();
-		SpotResponse spotResponse = spotService.findSpot(postSearchCond);
-		if (requireDistance) {
+		SpotResponse spotResponse = spotService.findSpot(postSearchCond, request.mostPostTagCount());
+		if (request.requireDistance()) {
 			distance = mapService.searchDistanceBetween(startingCoord.toCoord(), spotResponse.coord());
 		}
 		return SpotHttpResponse.of(distance, spotResponse);

--- a/src/main/java/com/tf4/photospot/spot/presentation/request/FindSpotHttpRequest.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/request/FindSpotHttpRequest.java
@@ -1,18 +1,27 @@
 package com.tf4.photospot.spot.presentation.request;
 
-import org.locationtech.jts.geom.Point;
-
-import com.tf4.photospot.global.util.PointConverter;
-
-import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
 
 public record FindSpotHttpRequest(
-	@NotNull
-	Double lat,
-	@NotNull
-	Double lon
+	@Range(max = 10, message = "미리보기 사진은 1~10장만 가능합니다.")
+	Integer postPreviewCount,
+	@Range(max = 5, message = "태그 통계는 1~5개만 가능합니다.")
+	Integer mostPostTagCount,
+	Boolean distance
 ) {
-	public Point toCoord() {
-		return PointConverter.convert(lat, lon);
+	public FindSpotHttpRequest {
+		if (postPreviewCount == null) {
+			postPreviewCount = 5;
+		}
+		if (mostPostTagCount == null) {
+			mostPostTagCount = 3;
+		}
+		if (distance == null) {
+			distance = true;
+		}
+	}
+
+	public boolean requireDistance() {
+		return distance;
 	}
 }

--- a/src/main/java/com/tf4/photospot/spot/presentation/response/SpotHttpResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/response/SpotHttpResponse.java
@@ -34,7 +34,7 @@ public record SpotHttpResponse(
 			.address(response.address())
 			.coord(PointConverter.convert(response.coord()))
 			.postCount(response.postCount())
-			.tags(response.postTagCounts())
+			.tags(response.mostPostTagRanks())
 			.photoUrls(response.previewResponses().stream().map(PostPreviewResponse::photoUrl).toList())
 			.bookmarked(response.bookmarked())
 			.build();

--- a/src/main/java/com/tf4/photospot/spot/presentation/response/SpotHttpResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/response/SpotHttpResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.tf4.photospot.global.dto.CoordinateDto;
 import com.tf4.photospot.global.util.PointConverter;
 import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.spot.application.response.MostPostTagRank;
 import com.tf4.photospot.spot.application.response.SpotResponse;
 
 import lombok.Builder;
@@ -15,6 +16,7 @@ public record SpotHttpResponse(
 	String address,
 	CoordinateDto coord,
 	Long postCount,
+	List<MostPostTagRank> tags,
 	List<String> photoUrls,
 	Boolean bookmarked
 ) {
@@ -32,6 +34,7 @@ public record SpotHttpResponse(
 			.address(response.address())
 			.coord(PointConverter.convert(response.coord()))
 			.postCount(response.postCount())
+			.tags(response.postTagCounts())
 			.photoUrls(response.previewResponses().stream().map(PostPreviewResponse::photoUrl).toList())
 			.bookmarked(response.bookmarked())
 			.build();

--- a/src/test/java/com/tf4/photospot/spot/application/SpotServiceTest.java
+++ b/src/test/java/com/tf4/photospot/spot/application/SpotServiceTest.java
@@ -297,7 +297,7 @@ class SpotServiceTest extends IntegrationTestSupport {
 		//when
 		final SpotResponse spotResponse = spotService.findSpot(searchCondition, 3);
 		//then
-		final List<MostPostTagRank> mostPostTagRanks = spotResponse.postTagCounts();
+		final List<MostPostTagRank> mostPostTagRanks = spotResponse.mostPostTagRanks();
 		assertThat(mostPostTagRanks).isNotEmpty();
 		assertThat(mostPostTagRanks).extracting("name").containsExactly("tag1", "tag2", "tag3");
 		assertThat(mostPostTagRanks).extracting("count").containsExactly(3, 2, 1);

--- a/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
@@ -119,7 +119,7 @@ public class SpotControllerDocsTest extends RestDocsSupport {
 			.previewResponses(List.of(
 				new PostPreviewResponse(1L, 2L, "photoUrl2"),
 				new PostPreviewResponse(1L, 1L, "photoUrl1")))
-			.postTagCounts(List.of(
+			.mostPostTagRanks(List.of(
 				MostPostTagRank.builder().id(1L).count(5).name("tagName").iconUrl("iconUrl").build(),
 				MostPostTagRank.builder().id(2L).count(10).name("tagName2").iconUrl("iconUrl2").build()
 			))


### PR DESCRIPTION
## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

- 스팟 조회시 태그 통계 기능

<br>

## 🙏🏻 To Reviewers

- 삭제된 방명록을 필터링하려면 성능 차이가 많이 나는데 개인적으로 삭제된 방명록을 제외하면서 태그를 계산할 필요가 있을까 싶은데 어떠신가요?

<br>