### PR TITLE
[refactor] 이미지 확장자명 추출 로직 수정

### DIFF
--- a/src/main/java/com/tf4/photospot/global/exception/domain/S3UploaderErrorCode.java
+++ b/src/main/java/com/tf4/photospot/global/exception/domain/S3UploaderErrorCode.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 public enum S3UploaderErrorCode implements ApiErrorCode {
 
 	EMPTY_FILE(HttpStatus.BAD_REQUEST, "비어있는 파일입니다."),
+	INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "파일명이 유효하지 않습니다."),
 	INVALID_PHOTO_EXTENSION(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 확장자입니다"),
 	NOT_FOUND_FILE(HttpStatus.NOT_FOUND, "지정된 경로에 파일이 존재하지 않습니다."),
 	UNEXPECTED_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류로 업로드를 실패했습니다."),

--- a/src/main/java/com/tf4/photospot/photo/application/S3Uploader.java
+++ b/src/main/java/com/tf4/photospot/photo/application/S3Uploader.java
@@ -37,10 +37,9 @@ public class S3Uploader {
 	private String bucket;
 
 	public String upload(MultipartFile file, String folder) {
-		validFileNotEmpty(file);
 		S3Directory s3Directory = S3Directory.findByFolder(folder)
 			.orElseThrow(() -> new ApiException(S3UploaderErrorCode.INVALID_PHOTO_EXTENSION));
-		String fileKey = s3Directory.getPath() + generateNewFileName(file.getContentType());
+		String fileKey = s3Directory.getPath() + generateNewFileName(validFileAndGetFileName(file));
 		try {
 			ObjectMetadata objectMetadata = generateObjectMetadata(file);
 			return s3Template.upload(bucket, fileKey, file.getInputStream(), objectMetadata).getURL().toString();
@@ -51,13 +50,15 @@ public class S3Uploader {
 		}
 	}
 
-	private void validFileNotEmpty(MultipartFile file) {
+	private String validFileAndGetFileName(MultipartFile file) {
 		if (file == null || file.isEmpty()) {
 			throw new ApiException(S3UploaderErrorCode.EMPTY_FILE);
 		}
+		return file.getOriginalFilename();
 	}
 
-	private String generateNewFileName(String contentType) {
+	private String generateNewFileName(String originalFileName) {
+		String contentType = originalFileName.substring(originalFileName.lastIndexOf(".") + 1);
 		Extension extension = Extension.getPhotoExtension(contentType)
 			.orElseThrow(() -> new ApiException(S3UploaderErrorCode.INVALID_PHOTO_EXTENSION));
 		String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));

--- a/src/main/java/com/tf4/photospot/photo/application/S3Uploader.java
+++ b/src/main/java/com/tf4/photospot/photo/application/S3Uploader.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.tf4.photospot.global.exception.ApiException;
@@ -53,6 +54,9 @@ public class S3Uploader {
 	private String validFileAndGetFileName(MultipartFile file) {
 		if (file == null || file.isEmpty()) {
 			throw new ApiException(S3UploaderErrorCode.EMPTY_FILE);
+		}
+		if (!StringUtils.hasText(file.getOriginalFilename())) {
+			throw new ApiException(S3UploaderErrorCode.INVALID_FILE_NAME);
 		}
 		return file.getOriginalFilename();
 	}

--- a/src/main/java/com/tf4/photospot/photo/application/S3Uploader.java
+++ b/src/main/java/com/tf4/photospot/photo/application/S3Uploader.java
@@ -52,7 +52,7 @@ public class S3Uploader {
 	}
 
 	private void validFileNotEmpty(MultipartFile file) {
-		if (file.isEmpty()) {
+		if (file == null || file.isEmpty()) {
 			throw new ApiException(S3UploaderErrorCode.EMPTY_FILE);
 		}
 	}

--- a/src/main/java/com/tf4/photospot/photo/domain/Extension.java
+++ b/src/main/java/com/tf4/photospot/photo/domain/Extension.java
@@ -17,7 +17,7 @@ public enum Extension {
 
 	public static Optional<Extension> getPhotoExtension(String contentType) {
 		return Arrays.stream(Extension.values())
-			.filter(extension -> ("image/" + extension.type).equals(contentType))
+			.filter(extension -> extension.type.equals(contentType))
 			.findFirst();
 	}
 }

--- a/src/test/java/com/tf4/photospot/photo/application/PhotoServiceTest.java
+++ b/src/test/java/com/tf4/photospot/photo/application/PhotoServiceTest.java
@@ -1,6 +1,7 @@
 package com.tf4.photospot.photo.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.DynamicTest.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -32,14 +33,14 @@ public class PhotoServiceTest extends IntegrationTestSupport {
 		var file = new MockMultipartFile("file", "test.webp", "image/webp", "<<webp data>>".getBytes());
 
 		return List.of(
-			DynamicTest.dynamicTest("사진 업로드에 성공한다", () -> {
+			dynamicTest("사진 업로드에 성공한다", () -> {
 				// when
 				String photoUrl = photoService.upload(file).photoUrl();
 
 				// then
 				assertThat(photoUrl).isEqualTo(mockS3Config.getDummyUrl());
 			}),
-			DynamicTest.dynamicTest("유효하지 않은 확장자 파일을 받으면 예외를 던진다.", () -> {
+			dynamicTest("유효하지 않은 확장자 파일을 받으면 예외를 던진다.", () -> {
 				// given
 				var gifFile = new MockMultipartFile("gif_file", "moving.gif", "image/gif", "<<gif data>>".getBytes());
 
@@ -47,62 +48,22 @@ public class PhotoServiceTest extends IntegrationTestSupport {
 				assertThatThrownBy(() -> photoService.upload(gifFile)).isInstanceOf(ApiException.class)
 					.hasMessage(S3UploaderErrorCode.INVALID_PHOTO_EXTENSION.getMessage());
 			}),
-			DynamicTest.dynamicTest("비어있는 파일을 받으면 예외를 던진다.", () -> {
+			dynamicTest("비어있는 파일을 받으면 예외를 던진다.", () -> {
 				// given
 				var emptyFile = new MockMultipartFile("empty_file", "empty.webp", "image/webp", new byte[0]);
 
 				// when & then
 				assertThatThrownBy(() -> photoService.upload(emptyFile)).isInstanceOf(ApiException.class)
 					.hasMessage(S3UploaderErrorCode.EMPTY_FILE.getMessage());
+			}),
+			dynamicTest("파일명이 유효하지 않으면 예외를 던진다.", () -> {
+				// given
+				var invalidFile = new MockMultipartFile("invalid_file", null, "image/webp", "<<webp data>>".getBytes());
+
+				// when & then
+				assertThatThrownBy(() -> photoService.upload(invalidFile)).isInstanceOf(ApiException.class)
+					.hasMessage(S3UploaderErrorCode.INVALID_FILE_NAME.getMessage());
 			})
 		);
 	}
-
-	// @TestFactory
-	// @DisplayName("사진 저장 시나리오")
-	// Collection<DynamicTest> savePhoto() {
-	// 	// given
-	// 	var file = new MockMultipartFile("file", "test.webp", "image/webp", "<<webp data>>".getBytes());
-	// 	String photoUrl = photoService.upload(file).photoUrl();
-	// 	Point coord = new GeometryFactory().createPoint(new Coordinate(23.0, 45.0));
-	// 	coord.setSRID(4326);
-	// 	LocalDate date = LocalDate.now().minusDays(1);
-	//
-	// 	return List.of(
-	// 		DynamicTest.dynamicTest("S3 temp 폴더에 저장된 사진을 post_images 폴더로 옮기고 사진 정보를 db에 저장한다.", () -> {
-	// 			// when
-	// 			PhotoSaveRequest request = new PhotoSaveRequest(photoUrl, coord, date);
-	// 			Long photoId = photoService.save(request).photoId();
-	// 			Photo savedPhoto = photoRepository.findById(photoId).get();
-	//
-	// 			// then
-	// 			assertAll(
-	// 				() -> assertThat(savedPhoto.getPhotoUrl()).doesNotContain(S3Directory.TEMP_FOLDER.getPath())
-	// 					.contains(S3Directory.POST_FOLDER.getPath()),
-	// 				() -> assertThat(savedPhoto.getPhotoUrl()).isEqualTo(mockS3Config.getDummyUrl()),
-	// 				() -> assertThat(savedPhoto.getTakenAt()).isEqualTo(date),
-	// 				() -> assertThat(savedPhoto.getCoord()).isEqualTo(coord)
-	// 			);
-	// 		}),
-	// 		DynamicTest.dynamicTest("파일 삭제 시 오류가 발생하는 경우 예외를 던진다", () -> {
-	// 			// when
-	// 			PhotoSaveRequest request = new PhotoSaveRequest(photoUrl, coord, date);
-	// 			mockS3Config.mockThrowExceptionOnDelete();
-	//
-	// 			// then
-	// 			assertThatThrownBy(() -> photoService.save(request)).isInstanceOf(ApiException.class)
-	// 				.hasMessage(S3UploaderErrorCode.UNEXPECTED_DELETE_FAIL.getMessage());
-	// 		}),
-	// 		DynamicTest.dynamicTest("파일 복사 시 오류가 발생하는 경우 예외를 던진다", () -> {
-	// 			// when
-	// 			PhotoSaveRequest request = new PhotoSaveRequest(photoUrl, coord, date);
-	// 			mockS3Config.mockThrowExceptionOnCopy();
-	//
-	// 			// then
-	// 			assertThatThrownBy(() -> photoService.save(request)).isInstanceOf(ApiException.class)
-	// 				.hasMessage(S3UploaderErrorCode.UNEXPECTED_COPY_FAIL.getMessage());
-	// 		})
-	// 	);
-	// }
-
 }

--- a/src/test/java/com/tf4/photospot/photo/application/S3UploaderTest.java
+++ b/src/test/java/com/tf4/photospot/photo/application/S3UploaderTest.java
@@ -1,6 +1,7 @@
 package com.tf4.photospot.photo.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.DynamicTest.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -31,7 +32,7 @@ public class S3UploaderTest extends IntegrationTestSupport {
 		var file = new MockMultipartFile("file", "example.webp", "image/webp", "<<webp data>>".getBytes());
 
 		return List.of(
-			DynamicTest.dynamicTest("방명록 사진을 업로드하는 경우 temp 폴더에 저장한다.", () -> {
+			dynamicTest("방명록 사진을 업로드하는 경우 temp 폴더에 저장한다.", () -> {
 				// given
 				String folder = S3Directory.TEMP_FOLDER.getFolder();
 
@@ -43,7 +44,7 @@ public class S3UploaderTest extends IntegrationTestSupport {
 					.doesNotContain(S3Directory.PROFILE_FOLDER.getPath())
 					.doesNotContain(S3Directory.POST_FOLDER.getPath());
 			}),
-			DynamicTest.dynamicTest("프로필 사진을 업로드하는 경우 profile 폴더에 저장한다.", () -> {
+			dynamicTest("프로필 사진을 업로드하는 경우 profile 폴더에 저장한다.", () -> {
 				//given
 				String folder = S3Directory.PROFILE_FOLDER.getFolder();
 


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 수정

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

우선 file 이름에서 확장자명을 추출하여 검증하는 방식으로 수정했습니다. 추후 라이브러리를 사용해 파일 확장자명을 검증하는 쪽으로 바꾸겠습니다.