### PR TITLE
[Feat] 사용자 장소 기간 별 필터링 기능 추가

### DIFF
--- a/src/docs/asciidoc/api/auth/auth.adoc
+++ b/src/docs/asciidoc/api/auth/auth.adoc
@@ -30,4 +30,5 @@ include::{snippets}/auth-controller-docs-test/reissue-token/response-fields.adoc
 
 include::{snippets}/auth-controller-docs-test/unlink-user/http-request.adoc[]
 include::{snippets}/auth-controller-docs-test/unlink-user/request-headers.adoc[]
-include::{snippets}/auth-controller-docs-test/unlink-user/query-parameters.adoc[]
+include::{snippets}/auth-controller-docs-test/unlink-user/request-fields.adoc[]
+include::{snippets}/auth-controller-docs-test/unlink-user/response-fields.adoc[]

--- a/src/docs/asciidoc/api/spot/spot.adoc
+++ b/src/docs/asciidoc/api/spot/spot.adoc
@@ -28,3 +28,10 @@ include::{snippets}/spot-controller-docs-test/get-spot/response-fields.adoc[]
 include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts/http-request.adoc[]
 include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts/response-body.adoc[]
 include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts/response-fields.adoc[]
+
+=== 특정 기간 내가 쓴 방명록의 장소 리스트 조회
+
+include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts-within-period/http-request.adoc[]
+include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts-within-period/query-parameters.adoc[]
+include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts-within-period/response-body.adoc[]
+include::{snippets}/spot-controller-docs-test/get-spots-of-my-posts-within-period/response-fields.adoc[]

--- a/src/main/java/com/tf4/photospot/auth/application/KakaoService.java
+++ b/src/main/java/com/tf4/photospot/auth/application/KakaoService.java
@@ -24,7 +24,7 @@ public class KakaoService {
 	@Value("${kakao.admin-key}")
 	private String adminKey;
 
-	private static final String KAKAO_AK_PREFIX = "KakaoAK";
+	private static final String KAKAO_AK_PREFIX = "KakaoAK ";
 
 	public AuthUserInfoDto getTokenInfo(String accessToken, String id) {
 		KakaoTokenInfoResponse response = kakaoClient.getTokenInfo(JwtConstant.PREFIX + accessToken);

--- a/src/main/java/com/tf4/photospot/global/argument/DateValidator.java
+++ b/src/main/java/com/tf4/photospot/global/argument/DateValidator.java
@@ -1,0 +1,48 @@
+package com.tf4.photospot.global.argument;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import com.tf4.photospot.spot.presentation.request.DateDto;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class DateValidator implements ConstraintValidator<ValidDate, DateDto> {
+	public static final String DATE_NOT_EMPTY = "시작일 또는 종료일에 빈 값이 들어갈 수 없습니다.";
+	public static final String INVALID_PERIOD = "시작일은 종료일 이전이어야 합니다.";
+	public static final String EXCEEDED_PERIOD = "선택한 기간이 7일을 초과합니다.";
+
+	@Override
+	public boolean isValid(DateDto value, ConstraintValidatorContext context) {
+		boolean isValid = true;
+		final LocalDate start = value.start();
+		final LocalDate end = value.end();
+
+		if (start == null || end == null) {
+			if (start == null) {
+				addConstraintViolationMessage(context, "start", DATE_NOT_EMPTY);
+			}
+			if (end == null) {
+				addConstraintViolationMessage(context, "end", DATE_NOT_EMPTY);
+			}
+			return false;
+		}
+		if (start.isAfter(end)) {
+			addConstraintViolationMessage(context, "start", INVALID_PERIOD);
+			isValid = false;
+		}
+		if (ChronoUnit.DAYS.between(start, end) + 1 > 7) {
+			addConstraintViolationMessage(context, "end", EXCEEDED_PERIOD);
+			isValid = false;
+		}
+		return isValid;
+	}
+
+	private void addConstraintViolationMessage(ConstraintValidatorContext context, String field, String message) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(message)
+			.addPropertyNode(field)
+			.addConstraintViolation();
+	}
+}

--- a/src/main/java/com/tf4/photospot/global/argument/ValidDate.java
+++ b/src/main/java/com/tf4/photospot/global/argument/ValidDate.java
@@ -1,0 +1,20 @@
+package com.tf4.photospot.global.argument;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Constraint(validatedBy = DateValidator.class)
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDate {
+	String message() default "날짜 형식이 잘못되었습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/tf4/photospot/global/exception/domain/SpotErrorCode.java
+++ b/src/main/java/com/tf4/photospot/global/exception/domain/SpotErrorCode.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SpotErrorCode implements ApiErrorCode {
-	INVALID_SPOT_ID(HttpStatus.BAD_REQUEST, "유효하지 않는 SPOT ID입니다.");
+	INVALID_SPOT_ID(HttpStatus.BAD_REQUEST, "유효하지 않는 SPOT ID입니다."),
+	INVALID_PERIOD(HttpStatus.BAD_REQUEST, "시작일이 종료일 이전이어야 합니다."),
+	EXCEEDED_PERIOD(HttpStatus.BAD_REQUEST, "선택한 기간이 7일을 초과합니다.");
 
 	private final HttpStatusCode statusCode;
 	private final String message;

--- a/src/main/java/com/tf4/photospot/spot/application/SpotService.java
+++ b/src/main/java/com/tf4/photospot/spot/application/SpotService.java
@@ -1,6 +1,5 @@
 package com.tf4.photospot.spot.application;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -42,8 +41,6 @@ public class SpotService {
 	private final PostJdbcRepository postJdbcRepository;
 	private final PostQueryRepository postQueryRepository;
 	private final UserService userService;
-
-	private static final DateTimeFormatter PERIOD_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
 	/*
 	 *	특정 좌표의 반경 내 추천 스팟들의 최신 방명록 미리보기를 조회합니다.

--- a/src/main/java/com/tf4/photospot/spot/application/response/IncludedPostResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/IncludedPostResponse.java
@@ -1,0 +1,13 @@
+package com.tf4.photospot.spot.application.response;
+
+import java.time.LocalDateTime;
+
+public record IncludedPostResponse(
+	Long postId,
+	String photoUrl,
+	LocalDateTime takenAt
+) {
+	public static IncludedPostResponse from(PeriodPostResponse response) {
+		return new IncludedPostResponse(response.postId(), response.photoUrl(), response.takenAt());
+	}
+}

--- a/src/main/java/com/tf4/photospot/spot/application/response/PeriodPostResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/PeriodPostResponse.java
@@ -1,0 +1,19 @@
+package com.tf4.photospot.spot.application.response;
+
+import java.time.LocalDateTime;
+
+import org.locationtech.jts.geom.Point;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record PeriodPostResponse(
+	Long postId,
+	Long spotId,
+	Point coord,
+	String photoUrl,
+	LocalDateTime takenAt
+) {
+	@QueryProjection
+	public PeriodPostResponse {
+	}
+}

--- a/src/main/java/com/tf4/photospot/spot/application/response/PeriodSpotResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/PeriodSpotResponse.java
@@ -1,0 +1,21 @@
+package com.tf4.photospot.spot.application.response;
+
+import java.util.List;
+
+import com.tf4.photospot.global.dto.CoordinateDto;
+import com.tf4.photospot.global.util.PointConverter;
+
+public record PeriodSpotResponse(
+	Long spotId,
+	CoordinateDto coord,
+	List<IncludedPostResponse> posts
+) {
+	public static PeriodSpotResponse from(List<PeriodPostResponse> responses) {
+		return new PeriodSpotResponse(
+			responses.get(0).spotId(),
+			PointConverter.convert(responses.get(0).coord()),
+			responses.stream()
+				.map(IncludedPostResponse::from)
+				.toList());
+	}
+}

--- a/src/main/java/com/tf4/photospot/spot/presentation/SpotController.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/SpotController.java
@@ -26,6 +26,7 @@ import com.tf4.photospot.spot.application.response.NearbySpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotListResponse;
 import com.tf4.photospot.spot.application.response.SpotResponse;
 import com.tf4.photospot.spot.presentation.request.FindSpotHttpRequest;
+import com.tf4.photospot.spot.presentation.response.PeriodSpotListResponse;
 import com.tf4.photospot.spot.presentation.response.RecommendedSpotHttpResponse;
 import com.tf4.photospot.spot.presentation.response.RecommendedSpotListHttpResponse;
 import com.tf4.photospot.spot.presentation.response.SpotHttpResponse;
@@ -99,5 +100,14 @@ public class SpotController {
 		@AuthUserId Long userId
 	) {
 		return UserSpotListHttpResponse.from(spotService.findSpotsOfMyPosts(userId));
+	}
+
+	@GetMapping("/mine/period")
+	public PeriodSpotListResponse getSpotsOfMyPostsWithinPeriod(
+		@AuthUserId Long userId,
+		@RequestParam("start") String start,
+		@RequestParam("end") String end
+	) {
+		return new PeriodSpotListResponse(spotService.findSpotsOfMyPostsWithinPeriod(userId, start, end));
 	}
 }

--- a/src/main/java/com/tf4/photospot/spot/presentation/SpotController.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/SpotController.java
@@ -25,6 +25,7 @@ import com.tf4.photospot.spot.application.request.RecommendedSpotsRequest;
 import com.tf4.photospot.spot.application.response.NearbySpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotListResponse;
 import com.tf4.photospot.spot.application.response.SpotResponse;
+import com.tf4.photospot.spot.presentation.request.DateDto;
 import com.tf4.photospot.spot.presentation.request.FindSpotHttpRequest;
 import com.tf4.photospot.spot.presentation.response.PeriodSpotListResponse;
 import com.tf4.photospot.spot.presentation.response.RecommendedSpotHttpResponse;
@@ -105,9 +106,8 @@ public class SpotController {
 	@GetMapping("/mine/period")
 	public PeriodSpotListResponse getSpotsOfMyPostsWithinPeriod(
 		@AuthUserId Long userId,
-		@RequestParam("start") String start,
-		@RequestParam("end") String end
+		@ModelAttribute @Valid DateDto dateDto
 	) {
-		return new PeriodSpotListResponse(spotService.findSpotsOfMyPostsWithinPeriod(userId, start, end));
+		return new PeriodSpotListResponse(spotService.findSpotsOfMyPostsWithinPeriod(userId, dateDto));
 	}
 }

--- a/src/main/java/com/tf4/photospot/spot/presentation/request/DateDto.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/request/DateDto.java
@@ -1,0 +1,12 @@
+package com.tf4.photospot.spot.presentation.request;
+
+import java.time.LocalDate;
+
+import com.tf4.photospot.global.argument.ValidDate;
+
+@ValidDate
+public record DateDto(
+	LocalDate start,
+	LocalDate end
+) {
+}

--- a/src/main/java/com/tf4/photospot/spot/presentation/response/PeriodSpotListResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/response/PeriodSpotListResponse.java
@@ -1,0 +1,10 @@
+package com.tf4.photospot.spot.presentation.response;
+
+import java.util.List;
+
+import com.tf4.photospot.spot.application.response.PeriodSpotResponse;
+
+public record PeriodSpotListResponse(
+	List<PeriodSpotResponse> spots
+) {
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -475,6 +475,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_주변_추천_장소_리스트_조회">주변 추천 장소 리스트 조회</a></li>
 <li><a href="#_특정_장소_조회">특정 장소 조회</a></li>
 <li><a href="#_내가_쓴_방명록의_장소_리스트_조회">내가 쓴 방명록의 장소 리스트 조회</a></li>
+<li><a href="#_특정_기간_내가_쓴_방명록의_장소_리스트_조회">특정 기간 내가 쓴 방명록의 장소 리스트 조회</a></li>
 </ul>
 </li>
 <li><a href="#_photo_api">photo API</a>
@@ -2181,6 +2182,131 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_특정_기간_내가_쓴_방명록의_장소_리스트_조회"><a class="link" href="#_특정_기간_내가_쓴_방명록의_장소_리스트_조회">특정 기간 내가 쓴 방명록의 장소 리스트 조회</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/spots/mine/period?start=2024.03.26&amp;end=2024.03.30 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_4"><a class="link" href="#_query_parameters_4">Query Parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Constraints</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>start</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 날짜보다 이전이어야 합니다.<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>end</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작일로부터 7일 이내까지 가능합니다.<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 날짜</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "spots" : [ {
+    "spotId" : 1,
+    "coord" : {
+      "lon" : 127.0468177,
+      "lat" : 37.6676198
+    },
+    "posts" : [ {
+      "postId" : 1,
+      "photoUrl" : "photo1.com",
+      "takenAt" : "2024-03-27T15:30:00"
+    }, {
+      "postId" : 2,
+      "photoUrl" : "photo2.com",
+      "takenAt" : "2024-03-29T11:20:00"
+    } ]
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spots[].spotId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">스팟 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spots[].coord.lat</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">위도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spots[].coord.lon</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">경도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spots[].posts[].postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사진 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spots[].posts[].photoUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사진 파일 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>spots[].posts[].takenAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사진 촬영 일자</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -2230,7 +2356,7 @@ Content-Type: image/webp
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
+<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2272,7 +2398,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_4"><a class="link" href="#_query_parameters_4">Query Parameters</a></h4>
+<h4 id="_query_parameters_5"><a class="link" href="#_query_parameters_5">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2335,7 +2461,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
+<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2390,7 +2516,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_5"><a class="link" href="#_query_parameters_5">Query Parameters</a></h4>
+<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2474,7 +2600,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
+<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2631,7 +2757,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">Query Parameters</a></h4>
+<h4 id="_query_parameters_7"><a class="link" href="#_query_parameters_7">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2686,7 +2812,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
+<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2741,7 +2867,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_7"><a class="link" href="#_query_parameters_7">Query Parameters</a></h4>
+<h4 id="_query_parameters_8"><a class="link" href="#_query_parameters_8">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2817,7 +2943,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
+<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2982,7 +3108,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
+<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3026,7 +3152,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
+<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3063,7 +3189,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_8"><a class="link" href="#_query_parameters_8">Query Parameters</a></h4>
+<h4 id="_query_parameters_9"><a class="link" href="#_query_parameters_9">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -3118,7 +3244,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
+<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3173,7 +3299,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_9"><a class="link" href="#_query_parameters_9">Query Parameters</a></h4>
+<h4 id="_query_parameters_10"><a class="link" href="#_query_parameters_10">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -3249,7 +3375,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
+<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3579,7 +3705,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
+<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3678,7 +3804,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
+<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3763,7 +3889,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
+<h4 id="_response_fields_25"><a class="link" href="#_response_fields_25">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3813,7 +3939,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_25"><a class="link" href="#_response_fields_25">Response Fields</a></h4>
+<h4 id="_response_fields_26"><a class="link" href="#_response_fields_26">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3865,7 +3991,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_26"><a class="link" href="#_response_fields_26">Response Fields</a></h4>
+<h4 id="_response_fields_27"><a class="link" href="#_response_fields_27">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3934,7 +4060,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_27"><a class="link" href="#_response_fields_27">Response Fields</a></h4>
+<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3976,7 +4102,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_10"><a class="link" href="#_query_parameters_10">Query Parameters</a></h4>
+<h4 id="_query_parameters_11"><a class="link" href="#_query_parameters_11">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -4031,7 +4157,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
+<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4103,7 +4229,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_11"><a class="link" href="#_query_parameters_11">Query Parameters</a></h4>
+<h4 id="_query_parameters_12"><a class="link" href="#_query_parameters_12">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -4158,7 +4284,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
+<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4213,7 +4339,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_12"><a class="link" href="#_query_parameters_12">Query Parameters</a></h4>
+<h4 id="_query_parameters_13"><a class="link" href="#_query_parameters_13">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -4289,7 +4415,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
+<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4460,7 +4586,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
+<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4511,7 +4637,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
+<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4630,7 +4756,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
+<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4718,7 +4844,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
+<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4771,7 +4897,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
+<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4808,7 +4934,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_13"><a class="link" href="#_query_parameters_13">Query Parameters</a></h4>
+<h4 id="_query_parameters_14"><a class="link" href="#_query_parameters_14">Query Parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -4866,7 +4992,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
+<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4953,7 +5079,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
+<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5040,7 +5166,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
+<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5084,7 +5210,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
+<h4 id="_response_fields_40"><a class="link" href="#_response_fields_40">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5157,7 +5283,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_40"><a class="link" href="#_response_fields_40">Response Fields</a></h4>
+<h4 id="_response_fields_41"><a class="link" href="#_response_fields_41">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1060,6 +1060,20 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않는 SPOT ID입니다.</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SpotErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>INVALID_PERIOD</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">INVALID_PERIOD</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작일이 종료일 이전이어야 합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SpotErrorCode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>EXCEEDED_PERIOD</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EXCEEDED_PERIOD</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택한 기간이 7일을 초과합니다.</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">UserErrorCode</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>NOT_FOUND_USER</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">NOT_FOUND_USER</p></td>
@@ -1328,8 +1342,59 @@ Host: localhost:8080
 </tr>
 </tbody>
 </table>
-<div class="paragraph">
-<p>Unresolved directive in api/auth/auth.adoc - include::/Users/ojeegu/coding/project/build/generated-snippets/auth-controller-docs-test/unlink-user/query-parameters.adoc[]</p>
+<div class="sect3">
+<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">Request Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Constraints</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>authorizationCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">카카오인 경우 null<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">apple 인증 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Default</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 </div>
@@ -1357,7 +1422,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">Response Fields</a></h4>
+<h4 id="_response_fields_6"><a class="link" href="#_response_fields_6">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1439,7 +1504,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_6"><a class="link" href="#_response_fields_6">Response Fields</a></h4>
+<h4 id="_response_fields_7"><a class="link" href="#_response_fields_7">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1483,7 +1548,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">Request Fields</a></h4>
+<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1517,7 +1582,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_7"><a class="link" href="#_response_fields_7">Response Fields</a></h4>
+<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1618,7 +1683,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1753,7 +1818,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
+<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1944,7 +2009,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
+<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2071,7 +2136,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">Response Fields</a></h4>
+<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2165,7 +2230,7 @@ Content-Type: image/webp
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
+<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2270,7 +2335,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
+<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2409,7 +2474,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
+<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2621,7 +2686,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
+<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2752,7 +2817,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
+<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2917,7 +2982,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
+<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2961,7 +3026,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
+<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3053,7 +3118,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
+<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3184,7 +3249,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
+<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3371,7 +3436,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h4>
+<h4 id="_request_fields_4"><a class="link" href="#_request_fields_4">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3514,7 +3579,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
+<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3566,7 +3631,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_4"><a class="link" href="#_request_fields_4">Request Fields</a></h4>
+<h4 id="_request_fields_5"><a class="link" href="#_request_fields_5">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3613,7 +3678,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
+<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3663,7 +3728,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_5"><a class="link" href="#_request_fields_5">Request Fields</a></h4>
+<h4 id="_request_fields_6"><a class="link" href="#_request_fields_6">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3698,7 +3763,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
+<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3748,7 +3813,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
+<h4 id="_response_fields_25"><a class="link" href="#_response_fields_25">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3800,7 +3865,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_25"><a class="link" href="#_response_fields_25">Response Fields</a></h4>
+<h4 id="_response_fields_26"><a class="link" href="#_response_fields_26">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3869,7 +3934,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_26"><a class="link" href="#_response_fields_26">Response Fields</a></h4>
+<h4 id="_response_fields_27"><a class="link" href="#_response_fields_27">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3966,7 +4031,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_27"><a class="link" href="#_response_fields_27">Response Fields</a></h4>
+<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4093,7 +4158,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
+<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4224,7 +4289,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
+<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4395,7 +4460,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
+<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4446,7 +4511,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
+<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4565,7 +4630,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
+<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4653,7 +4718,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
+<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4706,7 +4771,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
+<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4801,7 +4866,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
+<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4888,7 +4953,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
+<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4975,7 +5040,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
+<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5019,7 +5084,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
+<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5092,7 +5157,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
+<h4 id="_response_fields_40"><a class="link" href="#_response_fields_40">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5161,7 +5226,7 @@ Host: localhost:8080</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-28 23:19:22 +0900
+Last updated 2024-04-03 01:46:45 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -2186,7 +2186,7 @@ Host: localhost:8080</code></pre>
 <h3 id="_특정_기간_내가_쓴_방명록의_장소_리스트_조회"><a class="link" href="#_특정_기간_내가_쓴_방명록의_장소_리스트_조회">특정 기간 내가 쓴 방명록의 장소 리스트 조회</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/spots/mine/period?start=2024.03.26&amp;end=2024.03.30 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/spots/mine/period?start=2024-03-26&amp;end=2024-03-30 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2214,15 +2214,15 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>start</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">종료 날짜보다 이전이어야 합니다.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">시작 날짜</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료일보다 이전이어야 합니다.<br></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작일</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>end</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">시작일로부터 7일 이내까지 가능합니다.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">종료 날짜</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료일</p></td>
 </tr>
 </tbody>
 </table>

--- a/src/test/java/com/tf4/photospot/global/argument/DateValidatorTest.java
+++ b/src/test/java/com/tf4/photospot/global/argument/DateValidatorTest.java
@@ -1,0 +1,68 @@
+package com.tf4.photospot.global.argument;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.tf4.photospot.spot.presentation.request.DateDto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+public class DateValidatorTest {
+
+	private Validator validator;
+
+	@BeforeEach
+	public void setUp() {
+		validator = Validation.buildDefaultValidatorFactory().getValidator();
+	}
+
+	@Test
+	@DisplayName("유효한 날짜 기간이 들어오면 Validator를 통과한다.")
+	void dateValidSuccessTest() {
+		DateDto dateDto = new DateDto(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 5));
+		Set<ConstraintViolation<DateDto>> violations = validator.validate(dateDto);
+		assertThat(violations).isEmpty();
+	}
+
+	@MethodSource(value = "getDateTestData")
+	@ParameterizedTest(name = "{0}, validErrors {1}")
+	@DisplayName("빈 값 또는 유효하지 않는 날짜가 들어오면 ConstraintViolation가 추가된다.")
+	void dateValidFailTest(DateDto dateDto, Tuple... validErrors) {
+		String fieldPath = "propertyPath.currentLeafNode.name";
+		String errorMessagePath = "messageTemplate";
+		Set<ConstraintViolation<DateDto>> violations = validator.validate(dateDto);
+		assertThat(violations)
+			.extracting(fieldPath, errorMessagePath)
+			.contains(validErrors);
+	}
+
+	private static Stream<Arguments> getDateTestData() {
+		return Stream.of(
+			Arguments.of(new DateDto(null, LocalDate.of(2024, 1, 5)), new Tuple[] {
+				new Tuple("start", DateValidator.DATE_NOT_EMPTY)
+			}),
+			Arguments.of(new DateDto(LocalDate.of(2024, 1, 1), null), new Tuple[] {
+				new Tuple("end", DateValidator.DATE_NOT_EMPTY)
+			}),
+			Arguments.of(new DateDto(LocalDate.of(2024, 1, 7), LocalDate.of(2024, 1, 5)), new Tuple[] {
+				new Tuple("start", DateValidator.INVALID_PERIOD)
+			}),
+			Arguments.of(new DateDto(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 8)), new Tuple[] {
+				new Tuple("end", DateValidator.EXCEEDED_PERIOD)
+			})
+		);
+	}
+}

--- a/src/test/java/com/tf4/photospot/spot/presentation/SpotControllerTest.java
+++ b/src/test/java/com/tf4/photospot/spot/presentation/SpotControllerTest.java
@@ -154,4 +154,58 @@ class SpotControllerTest {
 			.andExpect(jsonPath("$.errors[0].value").value(radius))
 			.andExpect(jsonPath("$.errors[0].message").value("반경(m)은 0보다 커야 됩니다."));
 	}
+
+	@Test
+	@DisplayName("기간 조회 시 시작일이 빈 값이어선 안된다.")
+	void getSpotsFailWithStartNull() throws Exception {
+		String start = null;
+		mockMvc.perform(get("/api/v1/spots/mine/period")
+				.queryParam("start", start)
+				.queryParam("end", "2024-01-07"))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_PARAMETER"))
+			.andExpect(jsonPath("$.errors[0].message").value("시작일 또는 종료일에 빈 값이 들어갈 수 없습니다."))
+			.andExpect(jsonPath("$.errors[0].field").value("start"));
+	}
+
+	@Test
+	@DisplayName("기간 조회 시 종료일이 빈 값이어선 안된다.")
+	void getSpotsFailWithEndNull() throws Exception {
+		String end = null;
+		mockMvc.perform(get("/api/v1/spots/mine/period")
+				.queryParam("start", "2024-01-01")
+				.queryParam("end", end))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_PARAMETER"))
+			.andExpect(jsonPath("$.errors[0].message").value("시작일 또는 종료일에 빈 값이 들어갈 수 없습니다."))
+			.andExpect(jsonPath("$.errors[0].field").value("end"));
+	}
+
+	@Test
+	@DisplayName("기간 조회 시 시작일은 종료일 이전이어야 한다.")
+	void getSpotsFailWithinInvalidPeriod() throws Exception {
+		mockMvc.perform(get("/api/v1/spots/mine/period")
+				.queryParam("start", "2024-01-05")
+				.queryParam("end", "2024-01-01"))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_PARAMETER"))
+			.andExpect(jsonPath("$.errors[0].message").value("시작일은 종료일 이전이어야 합니다."))
+			.andExpect(jsonPath("$.errors[0].field").value("start"));
+	}
+
+	@Test
+	@DisplayName("기간 조회 시 7일을 초과할 수 없다.")
+	void getSpotsFailWithinExceededPeriod() throws Exception {
+		mockMvc.perform(get("/api/v1/spots/mine/period")
+				.queryParam("start", "2024-01-01")
+				.queryParam("end", "2024-01-08"))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_PARAMETER"))
+			.andExpect(jsonPath("$.errors[0].message").value("선택한 기간이 7일을 초과합니다."))
+			.andExpect(jsonPath("$.errors[0].field").value("end"));
+	}
 }

--- a/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -21,9 +22,11 @@ import com.tf4.photospot.post.application.response.PostPreviewResponse;
 import com.tf4.photospot.spot.application.SpotService;
 import com.tf4.photospot.spot.application.request.NearbySpotRequest;
 import com.tf4.photospot.spot.application.request.RecommendedSpotsRequest;
+import com.tf4.photospot.spot.application.response.IncludedPostResponse;
 import com.tf4.photospot.spot.application.response.MostPostTagRank;
 import com.tf4.photospot.spot.application.response.NearbySpotListResponse;
 import com.tf4.photospot.spot.application.response.NearbySpotResponse;
+import com.tf4.photospot.spot.application.response.PeriodSpotResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotListResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotResponse;
 import com.tf4.photospot.spot.application.response.SpotCoordResponse;
@@ -200,6 +203,35 @@ public class SpotControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("spots[].coord.lon").type(JsonFieldType.NUMBER).description("경도")
 				))
 			);
+	}
+
+	@Test
+	@DisplayName("특정 기간에 대한 스팟 조회")
+	public void getSpotsOfMyPostsWithinPeriod() throws Exception {
+		var post1 = new IncludedPostResponse(1L, "photo1.com", LocalDateTime.of(2024, 3, 27, 15, 30));
+		var post2 = new IncludedPostResponse(2L, "photo2.com", LocalDateTime.of(2024, 3, 29, 11, 20));
+		var spot = new PeriodSpotResponse(1L, DEFAULT_COORD, List.of(post1, post2));
+		given(spotService.findSpotsOfMyPostsWithinPeriod(anyLong(), anyString(), anyString())).willReturn(
+			List.of(spot));
+
+		mockMvc.perform(get("/api/v1/spots/mine/period")
+				.queryParam("start", "2024.03.26")
+				.queryParam("end", "2024.03.30"))
+			.andExpect(status().isOk())
+			.andDo(restDocsTemplate(
+				queryParameters(
+					parameterWithName("start").description("시작 날짜").attributes(constraints("종료 날짜보다 이전이어야 합니다.")),
+					parameterWithName("end").description("종료 날짜").attributes(constraints("시작일로부터 7일 이내까지 가능합니다."))
+				),
+				responseFields(
+					fieldWithPath("spots[].spotId").type(JsonFieldType.NUMBER).description("스팟 id"),
+					fieldWithPath("spots[].coord.lat").type(JsonFieldType.NUMBER).description("위도"),
+					fieldWithPath("spots[].coord.lon").type(JsonFieldType.NUMBER).description("경도"),
+					fieldWithPath("spots[].posts[].postId").type(JsonFieldType.NUMBER).description("사진 id"),
+					fieldWithPath("spots[].posts[].photoUrl").type(JsonFieldType.STRING).description("사진 파일 경로"),
+					fieldWithPath("spots[].posts[].takenAt").type(JsonFieldType.STRING).description("사진 촬영 일자")
+				)
+			));
 	}
 
 	private static SearchByCoordResponse createSearchByCoordResponse() {

--- a/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
@@ -32,6 +32,7 @@ import com.tf4.photospot.spot.application.response.RecommendedSpotResponse;
 import com.tf4.photospot.spot.application.response.SpotCoordResponse;
 import com.tf4.photospot.spot.application.response.SpotResponse;
 import com.tf4.photospot.spot.presentation.SpotController;
+import com.tf4.photospot.spot.presentation.request.DateDto;
 import com.tf4.photospot.spring.docs.RestDocsSupport;
 
 public class SpotControllerDocsTest extends RestDocsSupport {
@@ -211,17 +212,17 @@ public class SpotControllerDocsTest extends RestDocsSupport {
 		var post1 = new IncludedPostResponse(1L, "photo1.com", LocalDateTime.of(2024, 3, 27, 15, 30));
 		var post2 = new IncludedPostResponse(2L, "photo2.com", LocalDateTime.of(2024, 3, 29, 11, 20));
 		var spot = new PeriodSpotResponse(1L, DEFAULT_COORD, List.of(post1, post2));
-		given(spotService.findSpotsOfMyPostsWithinPeriod(anyLong(), anyString(), anyString())).willReturn(
+		given(spotService.findSpotsOfMyPostsWithinPeriod(anyLong(), any(DateDto.class))).willReturn(
 			List.of(spot));
 
 		mockMvc.perform(get("/api/v1/spots/mine/period")
-				.queryParam("start", "2024.03.26")
-				.queryParam("end", "2024.03.30"))
+				.queryParam("start", "2024-03-26")
+				.queryParam("end", "2024-03-30"))
 			.andExpect(status().isOk())
 			.andDo(restDocsTemplate(
 				queryParameters(
-					parameterWithName("start").description("시작 날짜").attributes(constraints("종료 날짜보다 이전이어야 합니다.")),
-					parameterWithName("end").description("종료 날짜").attributes(constraints("시작일로부터 7일 이내까지 가능합니다."))
+					parameterWithName("start").description("시작일").attributes(constraints("종료일보다 이전이어야 합니다.")),
+					parameterWithName("end").description("종료일").attributes(constraints("시작일로부터 7일 이내까지 가능합니다."))
 				),
 				responseFields(
 					fieldWithPath("spots[].spotId").type(JsonFieldType.NUMBER).description("스팟 id"),

--- a/src/test/java/com/tf4/photospot/support/TestFixture.java
+++ b/src/test/java/com/tf4/photospot/support/TestFixture.java
@@ -1,5 +1,6 @@
 package com.tf4.photospot.support;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -86,10 +87,11 @@ public class TestFixture {
 		return RANDOM.nextInt(LIKE_COUNT_RANGE);
 	}
 
-	public static Photo createPhoto(String photoUrl) {
+	public static Photo createPhoto(String photoUrl, LocalDateTime takenAt) {
 		return Photo.builder()
 			.photoUrl(photoUrl)
 			.coord(createPoint())
+			.takenAt(takenAt)
 			.build();
 	}
 
@@ -99,6 +101,10 @@ public class TestFixture {
 			.bubble(createBubble(text, posX, posY))
 			.coord(createPoint())
 			.build();
+	}
+
+	public static Photo createPhoto(String photoUrl) {
+		return createPhoto(photoUrl, LocalDateTime.now().minusDays(1));
 	}
 
 	public static Photo createPhoto() {


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 기간별 필터링(최대 7일) 기능 추가

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

- 사용자가 방명록 작성한 spot은 기존에 있는 것을 그대로 써도 될 것 같아서 따로 추가하지 않았습니다.
- 지난번 회의 때 타임라인 이야기가 나와서 우선 사진 이미지도 보여줄 수 있도록 구현했습니다.

<br>