### PR TITLE
[Feat] HTTP 요청 및 응답 로깅 추가

### DIFF
--- a/src/main/java/com/tf4/photospot/auth/application/JwtService.java
+++ b/src/main/java/com/tf4/photospot/auth/application/JwtService.java
@@ -43,6 +43,7 @@ public class JwtService {
 		this.key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
 	}
 
+	@Transactional
 	public String issueAccessToken(Long userId, String authorities) {
 		return generateAccessToken(userService.getActiveUser(userId).getId(), authorities, new Date());
 	}
@@ -58,6 +59,7 @@ public class JwtService {
 			.signWith(key).compact();
 	}
 
+	@Transactional
 	public String issueRefreshToken(Long userId) {
 		Long loginUserId = userService.getActiveUser(userId).getId();
 		String token = generateRefreshToken(loginUserId, new Date());

--- a/src/main/java/com/tf4/photospot/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tf4/photospot/global/exception/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(ApiException.class)
 	public ResponseEntity<Object> handleApiException(ApiException ex) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		return createResponse(ex.getErrorCode());
 	}
 
@@ -48,7 +48,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.flatMap(Collection::stream)
 			.map(error -> ValidationError.builder().message(error.getDefaultMessage()).build())
 			.toList();
-		log.error("ERRORS : {}", errorMessages);
+		log.info("ERRORS : {}", errorMessages);
 		return createResponse(CommonErrorCode.INVALID_PARAMETER, errorMessages);
 	}
 
@@ -59,7 +59,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		@NotNull HttpStatusCode status,
 		@NotNull WebRequest request
 	) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		final List<ValidationError> errors = ex.getBindingResult().getFieldErrors()
 			.stream()
 			.map(ValidationError::from)
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		return createResponse(CommonErrorCode.INVALID_PARAMETER);
 	}
 
@@ -77,7 +77,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	public ResponseEntity<Object> handleConstraintViolationException(
 		ConstraintViolationException ex
 	) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		final List<ValidationError> errors = ex.getConstraintViolations().stream()
 			.map(violation -> ValidationError.builder()
 				.field(violation.getPropertyPath().toString())
@@ -92,7 +92,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	public ResponseEntity<Object> handleMethodArgumentTypeMismatchException(
 		MethodArgumentTypeMismatchException ex
 	) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		final ValidationError error = ValidationError.builder()
 			.field(ex.getName())
 			.value(ex.getValue())
@@ -108,7 +108,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		@NotNull HttpStatusCode status,
 		@NotNull WebRequest request
 	) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		return createResponse(CommonErrorCode.MISSING_REQUEST_PARAMETER);
 	}
 
@@ -119,7 +119,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		@NotNull HttpStatusCode status,
 		@NotNull WebRequest request
 	) {
-		log.error(ex.getMessage());
+		log.info(ex.getMessage());
 		return createResponse(CommonErrorCode.MISSING_REQUEST_PARAMETER);
 	}
 

--- a/src/main/java/com/tf4/photospot/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tf4/photospot/global/exception/GlobalExceptionHandler.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(ApiException.class)
 	public ResponseEntity<Object> handleApiException(ApiException ex) {
+		log.error(ex.getMessage());
 		return createResponse(ex.getErrorCode());
 	}
 
@@ -47,6 +48,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.flatMap(Collection::stream)
 			.map(error -> ValidationError.builder().message(error.getDefaultMessage()).build())
 			.toList();
+		log.error("ERRORS : {}", errorMessages);
 		return createResponse(CommonErrorCode.INVALID_PARAMETER, errorMessages);
 	}
 

--- a/src/main/java/com/tf4/photospot/global/filter/CustomExceptionFilter.java
+++ b/src/main/java/com/tf4/photospot/global/filter/CustomExceptionFilter.java
@@ -11,7 +11,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class CustomExceptionFilter extends OncePerRequestFilter {
 
 	@Override
@@ -20,6 +22,7 @@ public class CustomExceptionFilter extends OncePerRequestFilter {
 		try {
 			filterChain.doFilter(request, response);
 		} catch (ApiException ex) {
+			log.error(ex.getMessage());
 			ErrorResponseFactory.create(request, response, ex);
 		}
 	}

--- a/src/main/java/com/tf4/photospot/global/filter/ReqResLoggingFilter.java
+++ b/src/main/java/com/tf4/photospot/global/filter/ReqResLoggingFilter.java
@@ -7,9 +7,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.slf4j.MDC;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
@@ -22,7 +22,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Component
+@Profile("dev")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ReqResLoggingFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/tf4/photospot/global/filter/ReqResLoggingFilter.java
+++ b/src/main/java/com/tf4/photospot/global/filter/ReqResLoggingFilter.java
@@ -1,0 +1,91 @@
+package com.tf4.photospot.global.filter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.springframework.web.util.WebUtils;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ReqResLoggingFilter extends OncePerRequestFilter {
+
+	private static final String REQUEST_ID = "request_id";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+		ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+		long startTime = System.currentTimeMillis();
+		filterChain.doFilter(requestWrapper, responseWrapper);
+		long endTime = System.currentTimeMillis();
+
+		try {
+			String requestId = UUID.randomUUID().toString().substring(0, 8);
+			MDC.put(REQUEST_ID, requestId);
+			log.info("""
+					[REQUEST] {} - {} {} - {}
+					HEADERS : {}
+					REQUEST PARAMS : {}
+					REQUEST BODY : {}
+					RESPONSE BODY : {}
+					""", request.getMethod(), request.getRequestURI(), responseWrapper.getStatus(),
+				(endTime - startTime) / 1000.0, getHeaders(request), getRequestParams(request),
+				getRequestBody(requestWrapper), getResponseBody(responseWrapper));
+			responseWrapper.copyBodyToResponse();
+		} catch (Exception ex) {
+			log.error("[" + this.getClass().getSimpleName() + "] Logging 실패", ex);
+		} finally {
+			MDC.remove(REQUEST_ID);
+		}
+	}
+
+	private Map<String, String> getHeaders(HttpServletRequest request) {
+		return Collections.list(request.getHeaderNames())
+			.stream()
+			.collect(Collectors.toMap(headerName -> headerName, request::getHeader));
+	}
+
+	private Map<String, String> getRequestParams(HttpServletRequest request) {
+		Map<String, String[]> params = request.getParameterMap();
+		return params.entrySet()
+			.stream()
+			.collect(Collectors.toMap(Map.Entry::getKey, entry -> String.join(", ", entry.getValue())));
+	}
+
+	private String getRequestBody(ContentCachingRequestWrapper requestWrapper) {
+		ContentCachingRequestWrapper wrapper = WebUtils.getNativeRequest(requestWrapper,
+			ContentCachingRequestWrapper.class);
+		if (wrapper != null && wrapper.getContentLength() > 0) {
+			return new String(wrapper.getContentAsByteArray());
+		}
+		return "";
+	}
+
+	private String getResponseBody(final HttpServletResponse response) {
+		ContentCachingResponseWrapper wrapper = WebUtils.getNativeResponse(response,
+			ContentCachingResponseWrapper.class);
+		if (wrapper != null && wrapper.getContentSize() > 0) {
+			return new String(wrapper.getContentAsByteArray());
+		}
+		return "";
+	}
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight([%-3level]) %magenta([%thread]) [%X{request_id}] %logger{5} - %msg %n"/>
+
+    <!--    Console appender 설정-->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <springProfile name="prod,dev">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/warn/warn.log</file>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                <charset>utf8</charset>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/warn/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/error/error.log</file>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                <charset>utf8</charset>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/error/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="APPLICATION_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/application/application.log</file>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                <charset>utf8</charset>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/application/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="WARN_FILE"/>
+            <appender-ref ref="ERROR_FILE"/>
+            <appender-ref ref="APPLICATION_FILE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -5352,7 +5352,7 @@ Host: localhost:8080</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-04-03 01:46:45 +0900
+Last updated 2024-04-06 23:43:15 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- HTTP 응답 및 요청 시 로그 기록 추가

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

- 로깅 필터를 추가하여 시큐리티 필터 이전에 동작하도록 구현했습니다. 다만 error log는 로깅 필터에서 처리할 수가 없어서 MDC를 적용하지 못했습니다. 이 부분은 추후 어떻게 하면 좋을지 고민해봐야 할 것 같습니다.
- prod와 dev에서는 파일로 저장될 수 있도록 스크립트를 작성했습니다.
- 로그 처리가 처음이라 블로그 글을 많이 참고했는데 혹시 이상한 부분이 있다면 말씀해주세요.
  - https://beaniejoy.tistory.com/97
  - https://medium.com/dong-gle/%EB%A1%9C%EA%B9%85-%EC%A0%95%EC%B1%85-768c658f0f8d


<br>