### PR TITLE
[Refactor] API 명세 수정 및 닉네임 valid 추가

### DIFF
--- a/src/docs/asciidoc/api/auth/auth.adoc
+++ b/src/docs/asciidoc/api/auth/auth.adoc
@@ -28,7 +28,7 @@ include::{snippets}/auth-controller-docs-test/reissue-token/response-fields.adoc
 
 '''
 
-include::{snippets}/auth-controller-docs-test/unlink-user/http-request.adoc[]
-include::{snippets}/auth-controller-docs-test/unlink-user/request-headers.adoc[]
-include::{snippets}/auth-controller-docs-test/unlink-user/request-fields.adoc[]
-include::{snippets}/auth-controller-docs-test/unlink-user/response-fields.adoc[]
+include::{snippets}/auth-controller-docs-test/withdrawal-user/http-request.adoc[]
+include::{snippets}/auth-controller-docs-test/withdrawal-user/request-headers.adoc[]
+include::{snippets}/auth-controller-docs-test/withdrawal-user/request-fields.adoc[]
+include::{snippets}/auth-controller-docs-test/withdrawal-user/response-fields.adoc[]

--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -10,16 +10,7 @@ include::{snippets}/user-controller-docs-test/get-user-info/response-fields.adoc
 
 '''
 
-include::{snippets}/user-controller-docs-test/update-profile/http-request.adoc[]
-include::{snippets}/user-controller-docs-test/update-profile/request-parts.adoc[]
-include::{snippets}/user-controller-docs-test/update-profile/response-body.adoc[]
-include::{snippets}/user-controller-docs-test/update-profile/response-fields.adoc[]
-
-=== 사용자 닉네임 업데이트
-
-'''
-
-include::{snippets}/user-controller-docs-test/update-nickname/http-request.adoc[]
-include::{snippets}/user-controller-docs-test/update-nickname/request-fields.adoc[]
-include::{snippets}/user-controller-docs-test/update-nickname/response-body.adoc[]
-include::{snippets}/user-controller-docs-test/update-nickname/response-fields.adoc[]
+include::{snippets}/user-controller-docs-test/update-user-info/http-request.adoc[]
+include::{snippets}/user-controller-docs-test/update-user-info/request-parts.adoc[]
+include::{snippets}/user-controller-docs-test/update-user-info/response-body.adoc[]
+include::{snippets}/user-controller-docs-test/update-user-info/response-fields.adoc[]

--- a/src/main/java/com/tf4/photospot/auth/presentation/AuthController.java
+++ b/src/main/java/com/tf4/photospot/auth/presentation/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
 		return authService.reissueToken(loginUserDto.getId(), refreshToken);
 	}
 
-	@PostMapping("/unlink")
+	@PostMapping("/withdrawal")
 	public ApiResponse unlinkUser(
 		@AuthUserId Long userId,
 		@RequestHeader(JwtConstant.AUTHORIZATION_HEADER) String accessToken,
@@ -45,7 +45,7 @@ public class AuthController {
 		return ApiResponse.SUCCESS;
 	}
 
-	@GetMapping("/unlink/callback")
+	@GetMapping("/withdrawal/callback")
 	public void deleteUnlinkedKakaoUser(
 		@RequestHeader(JwtConstant.AUTHORIZATION_HEADER) String adminKey,
 		@RequestParam("app_id") String appId,

--- a/src/main/java/com/tf4/photospot/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/tf4/photospot/global/config/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		return (web -> web.ignoring()
-			.requestMatchers("/api/v1/auth/unlink/callback")
+			.requestMatchers("/api/v1/auth/withdrawal/callback")
 			.requestMatchers("/docs/index.html")
 			.requestMatchers(PathRequest.toStaticResources().atCommonLocations()));
 	}

--- a/src/main/java/com/tf4/photospot/user/presentation/UserController.java
+++ b/src/main/java/com/tf4/photospot/user/presentation/UserController.java
@@ -2,7 +2,6 @@ package com.tf4.photospot.user.presentation;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,36 +11,31 @@ import com.tf4.photospot.global.argument.AuthUserId;
 import com.tf4.photospot.photo.application.S3Uploader;
 import com.tf4.photospot.photo.domain.S3Directory;
 import com.tf4.photospot.user.application.UserService;
-import com.tf4.photospot.user.application.response.NicknameUpdateResponse;
-import com.tf4.photospot.user.application.response.ProfileUpdateResponse;
 import com.tf4.photospot.user.application.response.UserInfoResponse;
 import com.tf4.photospot.user.presentation.request.NicknameUpdateRequest;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/user")
+@RequestMapping("/api/v1/users")
 public class UserController {
 
 	private final UserService userService;
 	private final S3Uploader s3Uploader;
 
-	@PatchMapping("/profile/me")
-	public ProfileUpdateResponse updateProfile(
-		@RequestPart("file") MultipartFile file,
-		@AuthUserId Long userId) {
-		String imageUrl = s3Uploader.upload(file, S3Directory.PROFILE_FOLDER.getFolder());
-		return userService.updateProfile(userId, imageUrl);
-	}
-
-	@PatchMapping("/nickname/me")
-	public NicknameUpdateResponse updateNickname(
+	@PatchMapping("/me")
+	public UserInfoResponse updateUserInfo(
 		@AuthUserId Long userId,
-		@RequestBody NicknameUpdateRequest request) {
-		return userService.updateNickname(userId, request.nickname());
+		@RequestPart(value = "file", required = false) MultipartFile file,
+		@RequestPart(value = "nicknameRequest", required = false) @Valid NicknameUpdateRequest nicknameRequest
+	) {
+		String imageUrl = file == null ? "" : s3Uploader.upload(file, S3Directory.PROFILE_FOLDER.getFolder());
+		String nickname = nicknameRequest == null ? "" : nicknameRequest.nickname();
+		return userService.updateUserInfo(userId, imageUrl, nickname);
 	}
 
 	@GetMapping("/me")

--- a/src/main/java/com/tf4/photospot/user/presentation/request/NicknameUpdateRequest.java
+++ b/src/main/java/com/tf4/photospot/user/presentation/request/NicknameUpdateRequest.java
@@ -1,4 +1,11 @@
 package com.tf4.photospot.user.presentation.request;
 
-public record NicknameUpdateRequest(String nickname) {
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record NicknameUpdateRequest(
+	@Pattern(regexp = "^[0-9a-zA-Zㄱ-ㅎ가-힣._]*$", message = "닉네임은 문자, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.")
+	@Size(max = 20, message = "닉네임은 최대 15자까지 입력할 수 있습니다.")
+	String nickname
+) {
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -466,7 +466,6 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_사용자_정보_조회">사용자 정보 조회</a></li>
 <li><a href="#_사용자_프로필_업데이트">사용자 프로필 업데이트</a></li>
-<li><a href="#_사용자_닉네임_업데이트">사용자 닉네임 업데이트</a></li>
 </ul>
 </li>
 <li><a href="#_spot_api">Spot API</a>
@@ -1314,7 +1313,7 @@ Host: localhost:8080</code></pre>
 <hr>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/unlink HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/withdrawal HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Content-Length: 32
@@ -1408,7 +1407,7 @@ Host: localhost:8080
 <hr>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/user/me HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/users/me HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1473,7 +1472,7 @@ Host: localhost:8080</code></pre>
 <hr>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/user/profile/me HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/users/me HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Accept: application/json
 Host: localhost:8080</code></pre>
@@ -1495,12 +1494,19 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>file</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사용자가 업로드한 프로필 사진</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nicknameRequest</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자가 변경하려는 닉네임</p></td>
+</tr>
 </tbody>
 </table>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "profileUrl" : "https://bucket.s3.ap-northeast-2.amazonaws.com/profile/example.webp"
+  "userId" : 1,
+  "nickname" : "새로운_닉네임",
+  "profileUrl" : "https://bucket.s3.ap-northeast-2.amazonaws.com/profile/example.webp",
+  "provider" : "kakao"
 }</code></pre>
 </div>
 </div>
@@ -1523,88 +1529,28 @@ Host: localhost:8080</code></pre>
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 닉네임</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileUrl</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">업로드 성공한 이미지 URL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 url</p></td>
 </tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_사용자_닉네임_업데이트"><a class="link" href="#_사용자_닉네임_업데이트">사용자 닉네임 업데이트</a></h3>
-<hr>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/user/nickname/me HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Accept: application/json
-Content-Length: 40
-Host: localhost:8080
-
-{
-  "nickname" : "새로운_닉네임"
-}</code></pre>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
 <tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Constraints</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>provider</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">바꾸려는 닉네임</p></td>
-</tr>
-</tbody>
-</table>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "nickname" : "새로운_닉네임"
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Default</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">바뀐 닉네임</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 계정 OAuth 공급자</p></td>
 </tr>
 </tbody>
 </table>
@@ -1684,7 +1630,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
+<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1819,7 +1765,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2010,7 +1956,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">Response Fields</a></h4>
+<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2137,7 +2083,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
+<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2250,7 +2196,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
+<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2356,7 +2302,7 @@ Content-Type: image/webp
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
+<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2461,7 +2407,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
+<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2600,7 +2546,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
+<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2812,7 +2758,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
+<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2943,7 +2889,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
+<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3108,7 +3054,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
+<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3152,7 +3098,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
+<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3244,7 +3190,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
+<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3375,7 +3321,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
+<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3562,7 +3508,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_4"><a class="link" href="#_request_fields_4">Request Fields</a></h4>
+<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3705,7 +3651,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
+<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3757,7 +3703,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_5"><a class="link" href="#_request_fields_5">Request Fields</a></h4>
+<h4 id="_request_fields_4"><a class="link" href="#_request_fields_4">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3804,7 +3750,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
+<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3854,7 +3800,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_6"><a class="link" href="#_request_fields_6">Request Fields</a></h4>
+<h4 id="_request_fields_5"><a class="link" href="#_request_fields_5">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3889,7 +3835,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_25"><a class="link" href="#_response_fields_25">Response Fields</a></h4>
+<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3939,7 +3885,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_26"><a class="link" href="#_response_fields_26">Response Fields</a></h4>
+<h4 id="_response_fields_25"><a class="link" href="#_response_fields_25">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3991,7 +3937,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_27"><a class="link" href="#_response_fields_27">Response Fields</a></h4>
+<h4 id="_response_fields_26"><a class="link" href="#_response_fields_26">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4060,7 +4006,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
+<h4 id="_response_fields_27"><a class="link" href="#_response_fields_27">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4157,7 +4103,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
+<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4284,7 +4230,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
+<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4415,7 +4361,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
+<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4586,7 +4532,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
+<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4637,7 +4583,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
+<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4756,7 +4702,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
+<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4844,7 +4790,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
+<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4897,7 +4843,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
+<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -4992,7 +4938,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
+<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5079,7 +5025,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
+<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5166,7 +5112,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
+<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5210,7 +5156,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_40"><a class="link" href="#_response_fields_40">Response Fields</a></h4>
+<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -5283,7 +5229,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_41"><a class="link" href="#_response_fields_41">Response Fields</a></h4>
+<h4 id="_response_fields_40"><a class="link" href="#_response_fields_40">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">

--- a/src/test/java/com/tf4/photospot/spring/docs/auth/AuthControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/auth/AuthControllerDocsTest.java
@@ -54,13 +54,13 @@ public class AuthControllerDocsTest extends RestDocsSupport {
 
 	@Test
 	@DisplayName("회원 탈퇴")
-	void unlinkUser() throws Exception {
+	void withdrawalUser() throws Exception {
 		// given
 		var request = new UnlinkRequest(null);
 		given(userService.getActiveUser(anyLong())).willReturn(createUser("사용자", "12345", "kakao"));
 
 		// when
-		mockMvc.perform(post("/api/v1/auth/unlink")
+		mockMvc.perform(post("/api/v1/auth/withdrawal")
 				.header("Authorization", "Bearer access_token")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(request)))

--- a/src/test/java/com/tf4/photospot/spring/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/user/UserControllerDocsTest.java
@@ -18,8 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.tf4.photospot.photo.application.S3Uploader;
 import com.tf4.photospot.spring.docs.RestDocsSupport;
 import com.tf4.photospot.user.application.UserService;
-import com.tf4.photospot.user.application.response.NicknameUpdateResponse;
-import com.tf4.photospot.user.application.response.ProfileUpdateResponse;
 import com.tf4.photospot.user.application.response.UserInfoResponse;
 import com.tf4.photospot.user.presentation.UserController;
 import com.tf4.photospot.user.presentation.request.NicknameUpdateRequest;
@@ -36,43 +34,35 @@ public class UserControllerDocsTest extends RestDocsSupport {
 	}
 
 	@Test
-	@DisplayName("프로필 수정")
-	void updateProfile() throws Exception {
+	void updateUserInfo() throws Exception {
 		// given
 		var profile = new MockMultipartFile("file", "image.webp", "image/webp", "<<image.webp>>".getBytes());
+		var nicknameRequest = new NicknameUpdateRequest("새로운_닉네임");
 		var imageUrl = "https://example.com/image.webp";
-		var response = new ProfileUpdateResponse("https://bucket.s3.ap-northeast-2.amazonaws.com/profile/example.webp");
+		var response = new UserInfoResponse(1L, "새로운_닉네임",
+			"https://bucket.s3.ap-northeast-2.amazonaws.com/profile/example.webp", "kakao");
 
 		given(s3Uploader.upload(any(MultipartFile.class), anyString())).willReturn(imageUrl);
-		given(userService.updateProfile(anyLong(), anyString())).willReturn(response);
+		given(userService.updateUserInfo(anyLong(), anyString(), anyString())).willReturn(response);
 
 		// when & then
-		mockMvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, "/api/v1/user/profile/me")
+		mockMvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, "/api/v1/users/me")
 				.file(profile)
+				.param("nicknameRequest", mapper.writeValueAsString(nicknameRequest))
 				.contentType(MediaType.MULTIPART_FORM_DATA)
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(restDocsTemplate(
-				requestParts(partWithName("file").description("사용자가 업로드한 프로필 사진")),
-				responseFields(fieldWithPath("profileUrl").type(JsonFieldType.STRING).description("업로드 성공한 이미지 URL"))
-			));
-	}
-
-	@Test
-	@DisplayName("닉네임 수정")
-	void updateNickname() throws Exception {
-		var request = new NicknameUpdateRequest("새로운_닉네임");
-		given(userService.updateNickname(anyLong(), anyString())).willReturn(new NicknameUpdateResponse("새로운_닉네임"));
-
-		mockMvc.perform(patch("/api/v1/user/nickname/me")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(request))
-				.accept(MediaType.APPLICATION_JSON))
-			.andExpect(status().isOk())
-			.andDo(restDocsTemplate(
-				requestFields(fieldWithPath("nickname").type(JsonFieldType.STRING).description("바꾸려는 닉네임")),
-				responseFields(fieldWithPath("nickname").type(JsonFieldType.STRING).description("바뀐 닉네임"))
-			));
+				requestParts(
+					partWithName("file").description("사용자가 업로드한 프로필 사진").optional(),
+					partWithName("nicknameRequest").description("사용자가 변경하려는 닉네임").optional()
+				),
+				responseFields(
+					fieldWithPath("userId").type(JsonFieldType.NUMBER).description("사용자 id"),
+					fieldWithPath("nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
+					fieldWithPath("profileUrl").type(JsonFieldType.STRING).description("사용자 프로필 url"),
+					fieldWithPath("provider").type(JsonFieldType.STRING).description("사용자 계정 OAuth 공급자")
+				)));
 	}
 
 	@Test
@@ -82,7 +72,7 @@ public class UserControllerDocsTest extends RestDocsSupport {
 			"https://bucket.s3.ap-northeast-2.amazonaws.com/profile/example.webp", "kakao");
 		given(userService.getInfo(anyLong())).willReturn(response);
 
-		mockMvc.perform(get("/api/v1/user/me"))
+		mockMvc.perform(get("/api/v1/users/me"))
 			.andExpect(status().isOk())
 			.andDo(restDocsTemplate(
 				responseFields(

--- a/src/test/java/com/tf4/photospot/user/presentation/request/UpdateUserInfoRequestTest.java
+++ b/src/test/java/com/tf4/photospot/user/presentation/request/UpdateUserInfoRequestTest.java
@@ -1,0 +1,64 @@
+package com.tf4.photospot.user.presentation.request;
+
+import static com.tf4.photospot.support.TestFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+public class UpdateUserInfoRequestTest {
+
+	private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	@ParameterizedTest
+	@MethodSource("provideValidNickname")
+	@DisplayName("유효한 닉네임 검증에 성공한다.")
+	void successValidUpdateUserInfoRequest(String nickname) {
+		NicknameUpdateRequest request = new NicknameUpdateRequest(nickname);
+		Set<ConstraintViolation<NicknameUpdateRequest>> violations = validator.validate(request);
+		assertTrue(violations.isEmpty());
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideInvalidNickname")
+	@DisplayName("유효하지 않은 문자가 포함된 닉네임 검증에 성공한다.")
+	void failUpdateUserInfoRequestWithInvalidCharacter(String nickname) {
+		NicknameUpdateRequest request = new NicknameUpdateRequest(nickname);
+		Set<ConstraintViolation<NicknameUpdateRequest>> violations = validator.validate(request);
+		assertThat(violations.stream().findFirst().map(ConstraintViolation::getMessage).orElseThrow())
+			.isEqualTo("닉네임은 문자, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.");
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideExceedNickname")
+	@DisplayName("글자수 20자 넘는 닉네임 검증에 성공한다.")
+	void failUpdateUserInfoRequestWithExceedSize(String nickname) {
+		NicknameUpdateRequest request = new NicknameUpdateRequest(nickname);
+		Set<ConstraintViolation<NicknameUpdateRequest>> violations = validator.validate(request);
+		assertThat(violations.stream().findFirst().map(ConstraintViolation::getMessage).orElseThrow())
+			.isEqualTo("닉네임은 최대 15자까지 입력할 수 있습니다.");
+	}
+
+	private static Stream<Arguments> provideValidNickname() {
+		return Stream.of(Arguments.of("한글닉네임", "engNickname", "number123", "허용_가능.닉네임"));
+	}
+
+	private static Stream<Arguments> provideInvalidNickname() {
+		return Stream.of(Arguments.of("불가능한/닉네임", "wrong*nickname", "fail 123", "틀린-닉네임"));
+	}
+
+	private static Stream<Arguments> provideExceedNickname() {
+		String nickname = createDummyStr(21);
+		return Stream.of(Arguments.of(nickname));
+	}
+}


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 사용자 api `user` 오타 -> `users` 수정
- 동훈님 피드백 적용
  - 프로필사진 수정과 닉네임 수정 하나의 api로 통합
  - 사용자 탈퇴 api `delete` -> `withdrawal`
- 닉네임 수정 시 Valid 추가
  -  문자, 숫자, 밑줄(_), 마침표(.)만 가능하며 20자 내 닉네임만 가능

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

- 사용자 정보 업데이트 API 명세서에서 nicknameRequest의 value 부분이 안 나오는데 추후 수정할 예정입니다.
- 동훈님이 재배포 하셔야 해서 우선은 merge 후 리뷰 받겠습니다(테스트코드, 포스트

<br>