### PR TITLE
[Feat] 회원탈퇴 시 account prefix 수정

### DIFF
--- a/src/main/java/com/tf4/photospot/user/infrastructure/UserQueryRepository.java
+++ b/src/main/java/com/tf4/photospot/user/infrastructure/UserQueryRepository.java
@@ -22,12 +22,12 @@ import lombok.RequiredArgsConstructor;
 public class UserQueryRepository extends QueryDslUtils {
 	private final JPAQueryFactory queryFactory;
 
-	private static final String DELETED_USER_ACCOUNT_PREFIX = "deleted_";
+	private static final String DELETED_USER_ACCOUNT_PREFIX = "_deleted_";
 
 	public void deleteByUserId(Long userId) {
 		final long deleted = queryFactory.update(user)
 			.set(user.deletedAt, LocalDateTime.now())
-			.set(user.account, user.account.prepend(DELETED_USER_ACCOUNT_PREFIX))
+			.set(user.account, user.account.prepend(userId + DELETED_USER_ACCOUNT_PREFIX))
 			.where(user.id.eq(userId).and(isActive()))
 			.execute();
 		if (deleted < 0) {

--- a/src/test/java/com/tf4/photospot/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/tf4/photospot/auth/application/AuthServiceTest.java
@@ -171,7 +171,7 @@ public class AuthServiceTest extends IntegrationTestSupport {
 				// then
 				assertAll(
 					() -> assertNotNull(deletedUser.getDeletedAt()),
-					() -> assertThat(deletedUser.getAccount()).startsWith("deleted_"),
+					() -> assertThat(deletedUser.getAccount()).startsWith(deletedUser.getId() + "_deleted_"),
 					() -> assertThat(jwtRedisRepository.findByUserId(deletedUser.getId())).isEqualTo(Optional.empty()),
 					() -> assertThat(userQueryRepository.findActiveUserById(deletedUser.getId())).isEqualTo(
 						Optional.empty()),
@@ -199,7 +199,7 @@ public class AuthServiceTest extends IntegrationTestSupport {
 				// then
 				assertAll(
 					() -> assertNotNull(deletedUser.getDeletedAt()),
-					() -> assertThat(deletedUser.getAccount()).startsWith("deleted_"),
+					() -> assertThat(deletedUser.getAccount()).startsWith(deletedUser.getId() + "_deleted_"),
 					() -> assertThat(jwtRedisRepository.findByUserId(deletedUser.getId())).isEqualTo(Optional.empty())
 				);
 				verify(slackAlert, times(0)).sendKakaoCallbackFailure(any(Exception.class), anyString(), anyString());


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 회원 탈퇴 시 account 속성 prefix를 unique하게 수정하여 가입->탈퇴->재가입을 여러 번 할 수 있도록 바꿨습니다.
  - (기존) deleted_account
  - (현재) userId_deleted_account

<br>