### PR TITLE
fix: 앨범 방명록 본인이 추가한 것만 보이도록 수정

### DIFF
--- a/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
@@ -65,8 +65,8 @@ public class PostQueryRepository extends QueryDslUtils {
 			query.join(postLike).on(postLike.post.eq(post));
 		}
 		if (searchType == PostSearchType.ALBUM_POSTS) {
-			query.join(albumPost).on(albumPost.post.eq(post))
-				.leftJoin(albumUser).on(albumUser.user.eq(post.writer));
+			query.join(albumPost).on(albumPost.post.eq(post));
+			query.leftJoin(albumUser).on(albumUser.user.eq(post.writer).and(albumPost.album.eq(albumUser.album)));
 		}
 		query.where(createPostSearchBuilder(cond));
 		return orderBy(query, getPostSearchPathBase(cond.type()), pageable).toSlice(query, pageable);
@@ -92,8 +92,8 @@ public class PostQueryRepository extends QueryDslUtils {
 			query.leftJoin(postLike).on(postLike.post.eq(post).and(equalsPostLike(cond.userId())));
 		}
 		if (searchType == PostSearchType.ALBUM_POSTS) {
-			query.join(albumPost).on(albumPost.post.eq(post))
-				.leftJoin(albumUser).on(albumUser.user.eq(post.writer));
+			query.join(albumPost).on(albumPost.post.eq(post));
+			query.leftJoin(albumUser).on(albumUser.user.eq(post.writer).and(albumPost.album.eq(albumUser.album)));
 		}
 		query.where(createPostSearchBuilder(cond));
 		return orderBy(query, getPostSearchPathBase(searchType), pageable).toSlice(query, pageable);
@@ -148,7 +148,7 @@ public class PostQueryRepository extends QueryDslUtils {
 			case POSTS_OF_SPOT -> searchBuilder.and(equalsSpot(cond.spotId())).and(canVisible(cond.userId()));
 			case LIKE_POSTS -> searchBuilder.and(equalsPostLike(cond.userId())).and(canVisible(cond.userId()));
 			case ALBUM_POSTS -> searchBuilder.and(equalsAlbum(cond.albumId()))
-				.and((isPublicPost())).or(albumUser.isNotNull());
+				.and(isPublicPost().or(albumUser.isNotNull()));
 		}
 		return searchBuilder;
 	}


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 버그 수정

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 앨범 방명록 본인이 추가한 것만 보이도록 수정

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

-

<br>