### PR TITLE
refactor: 방명록 목록 조회 시 작성자 id, 비공개 여부 정보 추가

### DIFF
--- a/src/main/java/com/tf4/photospot/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/tf4/photospot/bookmark/application/BookmarkService.java
@@ -23,7 +23,7 @@ import com.tf4.photospot.bookmark.infrastructure.BookmarkQueryRepository;
 import com.tf4.photospot.bookmark.presentation.request.ReadBookmarkRequest;
 import com.tf4.photospot.global.exception.ApiException;
 import com.tf4.photospot.global.exception.domain.BookmarkErrorCode;
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.application.SpotService;
 import com.tf4.photospot.spot.domain.Spot;
 import com.tf4.photospot.user.application.UserService;
@@ -63,12 +63,12 @@ public class BookmarkService {
 	public BookmarkListResponse getBookmarks(ReadBookmarkRequest request) {
 		Slice<Bookmark> bookmarks = bookmarkQueryRepository.findBookmarksOfFolder(
 			request.bookmarkFolderId(), request.userId(), request.pageable());
-		final Map<Long, List<PostPreviewResponse>> postPreviewsGroupBySpot = spotService.getRecentPostPreviewsInSpots(
+		final Map<Long, List<RecentPostPreviewResponse>> postPreviewsGroup = spotService.getRecentPostPreviewsInSpots(
 				bookmarks.map(Bookmark::getSpot).toList(), request.postPreviewCount())
 			.stream()
-			.collect(Collectors.groupingBy(PostPreviewResponse::spotId));
+			.collect(Collectors.groupingBy(RecentPostPreviewResponse::spotId));
 		final List<BookmarkResponse> bookmarkResponses = bookmarks.map(bookmark ->
-			BookmarkResponse.of(bookmark, postPreviewsGroupBySpot.get(bookmark.getSpotId()))).getContent();
+			BookmarkResponse.of(bookmark, postPreviewsGroup.get(bookmark.getSpotId()))).getContent();
 		return BookmarkListResponse.builder()
 			.bookmarks(bookmarkResponses)
 			.hasNext(bookmarks.hasNext())

--- a/src/main/java/com/tf4/photospot/bookmark/application/response/BookmarkResponse.java
+++ b/src/main/java/com/tf4/photospot/bookmark/application/response/BookmarkResponse.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.tf4.photospot.bookmark.domain.Bookmark;
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 
 import lombok.Builder;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -20,7 +20,7 @@ public record BookmarkResponse(
 	public BookmarkResponse {
 	}
 
-	public static BookmarkResponse of(Bookmark bookmark, List<PostPreviewResponse> postPreviewResponses) {
+	public static BookmarkResponse of(Bookmark bookmark, List<RecentPostPreviewResponse> postPreviewResponses) {
 		return BookmarkResponse.builder()
 			.id(bookmark.getId())
 			.spotId(bookmark.getSpotId())
@@ -30,10 +30,10 @@ public record BookmarkResponse(
 			.build();
 	}
 
-	private static List<String> getPhotoUrls(List<PostPreviewResponse> postPreviews) {
+	private static List<String> getPhotoUrls(List<RecentPostPreviewResponse> postPreviews) {
 		if (CollectionUtils.isNullOrEmpty(postPreviews)) {
 			return Collections.emptyList();
 		}
-		return postPreviews.stream().map(PostPreviewResponse::photoUrl).toList();
+		return postPreviews.stream().map(RecentPostPreviewResponse::photoUrl).toList();
 	}
 }

--- a/src/main/java/com/tf4/photospot/post/application/response/PostDetail.java
+++ b/src/main/java/com/tf4/photospot/post/application/response/PostDetail.java
@@ -6,7 +6,8 @@ import com.tf4.photospot.post.domain.Post;
 public record PostDetail(
 	Post post,
 	String spotAddress,
-	Boolean isLiked
+	Boolean isLiked,
+	Boolean isPrivate
 ) {
 	@QueryProjection
 	public PostDetail {

--- a/src/main/java/com/tf4/photospot/post/application/response/PostDetailResponse.java
+++ b/src/main/java/com/tf4/photospot/post/application/response/PostDetailResponse.java
@@ -15,6 +15,7 @@ public record PostDetailResponse(
 	int likeCount,
 	String photoUrl,
 	Boolean isLiked,
+	Boolean isPrivate,
 	LocalDateTime createdAt,
 	BubbleResponse bubble,
 	WriterResponse writer,
@@ -36,6 +37,7 @@ public record PostDetailResponse(
 			.createdAt(post.getCreatedAt())
 			.writer(WriterResponse.from(post.getWriter(), userId))
 			.isLiked(postDetail.isLiked())
+			.isPrivate(postDetail.isPrivate())
 			.tags(postTags.stream().map(TagResponse::from).toList())
 			.build();
 	}

--- a/src/main/java/com/tf4/photospot/post/application/response/PostPreviewResponse.java
+++ b/src/main/java/com/tf4/photospot/post/application/response/PostPreviewResponse.java
@@ -7,7 +7,9 @@ public record PostPreviewResponse(
 	@JsonIgnore
 	Long spotId,
 	Long postId,
-	String photoUrl
+	Long writerId,
+	String photoUrl,
+	Boolean isPrivate
 ) {
 	@QueryProjection
 	public PostPreviewResponse {

--- a/src/main/java/com/tf4/photospot/post/application/response/RecentPostPreviewResponse.java
+++ b/src/main/java/com/tf4/photospot/post/application/response/RecentPostPreviewResponse.java
@@ -1,0 +1,8 @@
+package com.tf4.photospot.post.application.response;
+
+public record RecentPostPreviewResponse(
+	Long spotId,
+	Long postId,
+	String photoUrl
+) {
+}

--- a/src/main/java/com/tf4/photospot/post/infrastructure/PostJdbcRepository.java
+++ b/src/main/java/com/tf4/photospot/post/infrastructure/PostJdbcRepository.java
@@ -10,7 +10,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.application.response.MostPostTagRank;
 import com.tf4.photospot.spot.domain.Spot;
 
@@ -29,7 +29,7 @@ public class PostJdbcRepository {
 	 *	스팟별로 파티션을 나눠서 최신 방명록을 postPreviewCount만큼 필터링합니다.
 	 * 	필터링이 된 방명록의 미리보기 정보(사진)를 가져옵니다.
 	 * */
-	public List<PostPreviewResponse> findRecentPostPreviewsInSpots(List<Spot> spots, int postPreviewCount) {
+	public List<RecentPostPreviewResponse> findRecentPostPreviewsInSpots(List<Spot> spots, int postPreviewCount) {
 		if (spots.isEmpty()) {
 			return Collections.emptyList();
 		}
@@ -46,7 +46,7 @@ public class PostJdbcRepository {
 			) as post
 			join photo on photo_id = photo.id
 			where recently_post <= :postPreviewCount
-			""", params, (rs, rowNum) -> new PostPreviewResponse(
+			""", params, (rs, rowNum) -> new RecentPostPreviewResponse(
 			rs.getLong("spot_id"),
 			rs.getLong("post_id"),
 			rs.getString("photo_url"))

--- a/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/tf4/photospot/post/infrastructure/PostQueryRepository.java
@@ -56,7 +56,9 @@ public class PostQueryRepository extends QueryDslUtils {
 		var query = queryFactory.select(new QPostPreviewResponse(
 				post.spot.id,
 				post.id,
-				photo.photoUrl
+				post.writer.id,
+				photo.photoUrl,
+				post.isPrivate
 			))
 			.from(post)
 			.join(post.photo, photo)
@@ -79,7 +81,8 @@ public class PostQueryRepository extends QueryDslUtils {
 		var query = queryFactory.select(new QPostDetail(
 				post,
 				spot.address,
-				postLike.isNotNull()))
+				postLike.isNotNull(),
+				post.isPrivate))
 			.from(post)
 			.join(post.spot, spot)
 			.join(post.writer, writer).fetchJoin()
@@ -114,7 +117,8 @@ public class PostQueryRepository extends QueryDslUtils {
 		return queryFactory.select(new QPostDetail(
 				post,
 				spot.address,
-				postLike.isNotNull()))
+				postLike.isNotNull(),
+				post.isPrivate))
 			.from(post)
 			.join(post.spot, spot)
 			.join(post.writer, writer).fetchJoin()

--- a/src/main/java/com/tf4/photospot/spot/application/SpotService.java
+++ b/src/main/java/com/tf4/photospot/spot/application/SpotService.java
@@ -12,6 +12,7 @@ import com.tf4.photospot.global.exception.ApiException;
 import com.tf4.photospot.global.exception.domain.SpotErrorCode;
 import com.tf4.photospot.post.application.request.PostSearchCondition;
 import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.post.infrastructure.PostJdbcRepository;
 import com.tf4.photospot.post.infrastructure.PostQueryRepository;
 import com.tf4.photospot.spot.application.request.NearbySpotRequest;
@@ -52,7 +53,7 @@ public class SpotService {
 		if (recommendedSpots.isEmpty()) {
 			return RecommendedSpotListResponse.emptyResponse();
 		}
-		final List<PostPreviewResponse> postPreviews = getRecentPostPreviewsInSpots(recommendedSpots.getContent(),
+		final List<RecentPostPreviewResponse> postPreviews = getRecentPostPreviewsInSpots(recommendedSpots.getContent(),
 			request.postPreviewCount());
 		return RecommendedSpotListResponse.of(recommendedSpots, postPreviews);
 	}
@@ -80,7 +81,7 @@ public class SpotService {
 			.orElseThrow(() -> new ApiException(SpotErrorCode.INVALID_SPOT_ID));
 	}
 
-	public List<PostPreviewResponse> getRecentPostPreviewsInSpots(List<Spot> spots, int postPreviewCount) {
+	public List<RecentPostPreviewResponse> getRecentPostPreviewsInSpots(List<Spot> spots, int postPreviewCount) {
 		return postJdbcRepository.findRecentPostPreviewsInSpots(spots, postPreviewCount);
 	}
 

--- a/src/main/java/com/tf4/photospot/spot/application/response/RecommendedSpotListResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/RecommendedSpotListResponse.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Slice;
 
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.domain.Spot;
 
 import lombok.Builder;
@@ -21,9 +21,9 @@ public record RecommendedSpotListResponse(
 		return new RecommendedSpotListResponse(Collections.emptyList(), false);
 	}
 
-	public static RecommendedSpotListResponse of(Slice<Spot> spots, List<PostPreviewResponse> postPreviews) {
-		Map<Long, List<PostPreviewResponse>> spotPostPreviews = postPreviews.stream()
-			.collect(Collectors.groupingBy(PostPreviewResponse::spotId));
+	public static RecommendedSpotListResponse of(Slice<Spot> spots, List<RecentPostPreviewResponse> postPreviews) {
+		Map<Long, List<RecentPostPreviewResponse>> spotPostPreviews = postPreviews.stream()
+			.collect(Collectors.groupingBy(RecentPostPreviewResponse::spotId));
 		return RecommendedSpotListResponse.builder()
 			.recommendedSpots(spots.stream()
 				.map(spot -> RecommendedSpotResponse.of(

--- a/src/main/java/com/tf4/photospot/spot/application/response/RecommendedSpotResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/application/response/RecommendedSpotResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.tf4.photospot.global.dto.CoordinateDto;
 import com.tf4.photospot.global.util.PointConverter;
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.domain.Spot;
 
 import lombok.Builder;
@@ -15,9 +15,9 @@ public record RecommendedSpotResponse(
 	String address,
 	Long postCount,
 	CoordinateDto coord,
-	List<PostPreviewResponse> postPreviewResponses
+	List<RecentPostPreviewResponse> postPreviewResponses
 ) {
-	public static RecommendedSpotResponse of(Spot spot, List<PostPreviewResponse> postPreviewResponses) {
+	public static RecommendedSpotResponse of(Spot spot, List<RecentPostPreviewResponse> postPreviewResponses) {
 		return RecommendedSpotResponse.builder()
 			.id(spot.getId())
 			.address(spot.getAddress())

--- a/src/main/java/com/tf4/photospot/spot/presentation/response/RecommendedSpotHttpResponse.java
+++ b/src/main/java/com/tf4/photospot/spot/presentation/response/RecommendedSpotHttpResponse.java
@@ -3,7 +3,7 @@ package com.tf4.photospot.spot.presentation.response;
 import java.util.List;
 
 import com.tf4.photospot.global.dto.CoordinateDto;
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.application.response.RecommendedSpotResponse;
 
 import lombok.Builder;
@@ -24,7 +24,7 @@ public record RecommendedSpotHttpResponse(
 				.postCount(response.postCount())
 				.coord(response.coord())
 				.photoUrls(response.postPreviewResponses().stream()
-					.map(PostPreviewResponse::photoUrl)
+					.map(RecentPostPreviewResponse::photoUrl)
 					.toList())
 				.build())
 			.toList();

--- a/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
+++ b/src/test/java/com/tf4/photospot/post/application/PostServiceTest.java
@@ -12,12 +12,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.Executable;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -816,5 +816,44 @@ class PostServiceTest extends IntegrationTestSupport {
 
 		//then
 		assertThrows(ApiException.class, action, PostErrorCode.CAN_NOT_DELETE_POSTS.getMessage());
+	}
+
+	@DisplayName("방명록 목록 조회 시 비공개 여부를 알 수 있다.")
+	@Test
+	void getPostDetailListContainsPrivateOrNot() {
+		//given
+		Spot spot = spotRepository.save(createSpot("spot address", createPoint(), 0L));
+		User me = userRepository.save(createUser("본인"));
+		User other = userRepository.save(createUser("다른사람"));
+		postRepository.saveAll(List.of(
+			createPost(spot, me, true),
+			createPost(spot, me, false),
+			createPost(spot, other, true),
+			createPost(spot, other, false)
+		));
+		var postSearchCondition = PostSearchCondition.builder()
+			.spotId(spot.getId())
+			.userId(me.getId())
+			.type(PostSearchType.POSTS_OF_SPOT)
+			.pageable(PageRequest.of(0, 10))
+			.build();
+		//when
+		var postList = postService.getPosts(postSearchCondition).content();
+		var postPreviewList = postService.getPostPreviews(postSearchCondition).content();
+		//then
+		assertThat(postList).hasSize(3)
+			.extracting("writer.id", "isPrivate")
+			.containsAnyOf(
+				new Tuple(me.getId(), true),
+				new Tuple(me.getId(), false),
+				new Tuple(other.getId(), false)
+			);
+		assertThat(postPreviewList).hasSize(3)
+			.extracting("writerId", "isPrivate")
+			.containsAnyOf(
+				new Tuple(me.getId(), true),
+				new Tuple(me.getId(), false),
+				new Tuple(other.getId(), false)
+			);
 	}
 }

--- a/src/test/java/com/tf4/photospot/spot/application/SpotServiceTest.java
+++ b/src/test/java/com/tf4/photospot/spot/application/SpotServiceTest.java
@@ -32,6 +32,7 @@ import com.tf4.photospot.photo.domain.Photo;
 import com.tf4.photospot.post.application.request.PostSearchCondition;
 import com.tf4.photospot.post.application.request.PostSearchType;
 import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.post.domain.Post;
 import com.tf4.photospot.post.domain.PostRepository;
 import com.tf4.photospot.post.domain.PostTagRepository;
@@ -197,7 +198,7 @@ class SpotServiceTest extends IntegrationTestSupport {
 				//then
 				assertThat(response.recommendedSpots()).isNotEmpty().allSatisfy(recommendedSpot ->
 					assertThat(recommendedSpot.postPreviewResponses())
-						.isSortedAccordingTo(comparingLong(PostPreviewResponse::postId).reversed())
+						.isSortedAccordingTo(comparingLong(RecentPostPreviewResponse::postId).reversed())
 				);
 			}),
 			dynamicTest("다음 추천 스팟 목록이 있으면 hasNext = true를 반환한다", () -> {
@@ -273,11 +274,11 @@ class SpotServiceTest extends IntegrationTestSupport {
 		//when
 		var postPreviewsGroupBySpot = spotService.getRecentPostPreviewsInSpots(List.of(spot1, spot2), 5)
 			.stream()
-			.collect(Collectors.groupingBy(PostPreviewResponse::spotId))
+			.collect(Collectors.groupingBy(RecentPostPreviewResponse::spotId))
 			.values();
 		//then
 		assertThat(postPreviewsGroupBySpot).isNotEmpty().allSatisfy(postPreviews ->
-			assertThat(postPreviews).isSortedAccordingTo(comparingLong(PostPreviewResponse::postId).reversed()));
+			assertThat(postPreviews).isSortedAccordingTo(comparingLong(RecentPostPreviewResponse::postId).reversed()));
 	}
 
 	@DisplayName("스팟의 태그 통계를 조회한다.")

--- a/src/test/java/com/tf4/photospot/spot/presentation/SpotControllerTest.java
+++ b/src/test/java/com/tf4/photospot/spot/presentation/SpotControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import com.tf4.photospot.global.dto.CoordinateDto;
 import com.tf4.photospot.map.application.MapService;
 import com.tf4.photospot.mockobject.WithCustomMockUser;
-import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.application.SpotService;
 import com.tf4.photospot.spot.application.request.NearbySpotRequest;
 import com.tf4.photospot.spot.application.request.RecommendedSpotsRequest;
@@ -111,9 +111,9 @@ class SpotControllerTest {
 			.coord(new CoordinateDto(127.0, 37.0))
 			.postCount(5L)
 			.postPreviewResponses(List.of(
-				new PostPreviewResponse(1L, 1L, "profileUrl"),
-				new PostPreviewResponse(1L, 1L, "profileUrl"),
-				new PostPreviewResponse(1L, 1L, "profileUrl")))
+				new RecentPostPreviewResponse(1L, 1L, "profileUrl"),
+				new RecentPostPreviewResponse(1L, 1L, "profileUrl"),
+				new RecentPostPreviewResponse(1L, 1L, "profileUrl")))
 			.build();
 	}
 

--- a/src/test/java/com/tf4/photospot/spring/docs/album/AlbumControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/album/AlbumControllerDocsTest.java
@@ -45,7 +45,7 @@ public class AlbumControllerDocsTest extends RestDocsSupport {
 	void getPostPreviews() throws Exception {
 		//given
 		var response = SlicePageDto.wrap(List.of(
-			new PostPreviewResponse(1L, 1L, "photoUrl")), false);
+			new PostPreviewResponse(1L, 1L, 1L, "photoUrl", false)), false);
 		given(albumService.getPostPreviewsOfAlbum(any(PostSearchCondition.class))).willReturn(response);
 		//when
 		mockMvc.perform(get("/api/v1/albums/{albumId}/posts/preview", 1L)
@@ -67,7 +67,9 @@ public class AlbumControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("content").type(JsonFieldType.ARRAY).description("방명록 상세 목록 리스트")
 						.attributes(defaultValue("emptyList")),
 					fieldWithPath("content[].postId").type(JsonFieldType.NUMBER).description("방명록 ID"),
+					fieldWithPath("content[].writerId").type(JsonFieldType.NUMBER).description("작성자 ID"),
 					fieldWithPath("content[].photoUrl").type(JsonFieldType.STRING).description("방명록 photo url"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 방명록 여부")
 				)));
 	}
@@ -81,6 +83,7 @@ public class AlbumControllerDocsTest extends RestDocsSupport {
 			.detailAddress("detail address")
 			.likeCount(10)
 			.photoUrl("photoUrl")
+			.isPrivate(false)
 			.bubble(new BubbleResponse("이미지 설명", 100, 200))
 			.isLiked(true)
 			.createdAt(LocalDateTime.of(2024, 1, 10, 12, 30))
@@ -120,6 +123,7 @@ public class AlbumControllerDocsTest extends RestDocsSupport {
 						.description("방명록 좋아요 여부"),
 					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("방명록 생성일")
 						.description("생성"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("content[].writer.id").type(JsonFieldType.NUMBER).description("작성자 ID"),
 					fieldWithPath("content[].writer.isWriter").type(JsonFieldType.BOOLEAN).description("작성자 본인 여부"),
 					fieldWithPath("content[].writer.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),

--- a/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/post/PostControllerDocsTest.java
@@ -52,7 +52,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 	void getPostPreviews() throws Exception {
 		//given
 		var response = SlicePageDto.wrap(List.of(
-			new PostPreviewResponse(1L, 1L, "photoUrl")), false);
+			new PostPreviewResponse(1L, 1L, 1L, "photoUrl", false)), false);
 		given(postService.getPostPreviews(any(PostSearchCondition.class))).willReturn(response);
 		//when
 		mockMvc.perform(get("/api/v1/posts/preview")
@@ -76,6 +76,8 @@ public class PostControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("content").type(JsonFieldType.ARRAY).description("방명록 상세 목록 리스트")
 						.attributes(defaultValue("emptyList")),
 					fieldWithPath("content[].postId").type(JsonFieldType.NUMBER).description("방명록 ID"),
+					fieldWithPath("content[].writerId").type(JsonFieldType.NUMBER).description("작성자 ID"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("content[].photoUrl").type(JsonFieldType.STRING).description("방명록 photo url"),
 					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 방명록 여부")
 				)));
@@ -89,6 +91,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 			.address("spot address")
 			.detailAddress("detail address")
 			.likeCount(10)
+			.isPrivate(false)
 			.photoUrl("photoUrl")
 			.bubble(new BubbleResponse("이미지 설명", 100, 200))
 			.isLiked(true)
@@ -128,6 +131,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("content[].bubble.y").type(JsonFieldType.NUMBER).description("bubble 위치 y 좌표"),
 					fieldWithPath("content[].isLiked").type(JsonFieldType.BOOLEAN)
 						.description("방명록 좋아요 여부"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("방명록 생성일")
 						.description("생성"),
 					fieldWithPath("content[].writer.id").type(JsonFieldType.NUMBER).description("작성자 ID"),
@@ -149,7 +153,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 	void getMyPostPreviews() throws Exception {
 		//given
 		var response = SlicePageDto.wrap(List.of(
-			new PostPreviewResponse(1L, 1L, "photoUrl")), false);
+			new PostPreviewResponse(1L, 1L, 1L, "photoUrl", false)), false);
 		given(postService.getPostPreviews(any(PostSearchCondition.class))).willReturn(response);
 		//when
 		mockMvc.perform(get("/api/v1/posts/mine/preview")
@@ -170,7 +174,9 @@ public class PostControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("content").type(JsonFieldType.ARRAY).description("방명록 상세 목록 리스트")
 						.attributes(defaultValue("emptyList")),
 					fieldWithPath("content[].postId").type(JsonFieldType.NUMBER).description("방명록 ID"),
+					fieldWithPath("content[].writerId").type(JsonFieldType.NUMBER).description("작성자 ID"),
 					fieldWithPath("content[].photoUrl").type(JsonFieldType.STRING).description("방명록 photo url"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 방명록 여부")
 				)));
 	}
@@ -184,6 +190,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 			.detailAddress("detail address")
 			.likeCount(10)
 			.photoUrl("photoUrl")
+			.isPrivate(false)
 			.bubble(new BubbleResponse("이미지 설명", 100, 200))
 			.isLiked(true)
 			.createdAt(LocalDateTime.of(2024, 1, 10, 12, 30))
@@ -216,6 +223,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("content[].photoUrl").type(JsonFieldType.STRING).description("방명록 photo url"),
 					fieldWithPath("content[].isLiked").type(JsonFieldType.BOOLEAN)
 						.description("방명록 좋아요 여부"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("방명록 생성일")
 						.description("생성"),
 					fieldWithPath("content[].writer.id").type(JsonFieldType.NUMBER).description("작성자 ID"),
@@ -241,7 +249,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 	void getLikePostPreviews() throws Exception {
 		//given
 		var response = SlicePageDto.wrap(List.of(
-			new PostPreviewResponse(1L, 1L, "photoUrl")), false);
+			new PostPreviewResponse(1L, 1L, 1L, "photoUrl", false)), false);
 		given(postService.getPostPreviews(any(PostSearchCondition.class))).willReturn(response);
 		//when
 		mockMvc.perform(get("/api/v1/posts/likes/preview")
@@ -262,7 +270,9 @@ public class PostControllerDocsTest extends RestDocsSupport {
 					fieldWithPath("content").type(JsonFieldType.ARRAY).description("방명록 상세 목록 리스트")
 						.attributes(defaultValue("emptyList")),
 					fieldWithPath("content[].postId").type(JsonFieldType.NUMBER).description("방명록 ID"),
+					fieldWithPath("content[].writerId").type(JsonFieldType.NUMBER).description("작성자 ID"),
 					fieldWithPath("content[].photoUrl").type(JsonFieldType.STRING).description("방명록 photo url"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 방명록 여부")
 				)));
 	}
@@ -275,6 +285,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 			.address("spot address")
 			.detailAddress("detail address")
 			.likeCount(10)
+			.isPrivate(false)
 			.photoUrl("photoUrl")
 			.bubble(new BubbleResponse("이미지 설명", 100, 200))
 			.isLiked(true)
@@ -310,6 +321,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 						.description("방명록 좋아요 여부"),
 					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("방명록 생성일")
 						.description("생성"),
+					fieldWithPath("content[].isPrivate").type(JsonFieldType.BOOLEAN).description("비공개 여부"),
 					fieldWithPath("content[].writer.id").type(JsonFieldType.NUMBER).description("작성자 ID"),
 					fieldWithPath("content[].writer.isWriter").type(JsonFieldType.BOOLEAN).description("작성자 본인 여부"),
 					fieldWithPath("content[].writer.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),

--- a/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
+++ b/src/test/java/com/tf4/photospot/spring/docs/spot/SpotControllerDocsTest.java
@@ -18,6 +18,7 @@ import com.tf4.photospot.global.dto.CoordinateDto;
 import com.tf4.photospot.map.application.MapService;
 import com.tf4.photospot.post.application.request.PostSearchCondition;
 import com.tf4.photospot.post.application.response.PostPreviewResponse;
+import com.tf4.photospot.post.application.response.RecentPostPreviewResponse;
 import com.tf4.photospot.spot.application.SpotService;
 import com.tf4.photospot.spot.application.request.NearbySpotRequest;
 import com.tf4.photospot.spot.application.request.RecommendedSpotsRequest;
@@ -120,8 +121,8 @@ public class SpotControllerDocsTest extends RestDocsSupport {
 			.coord(DEFAULT_COORD.toCoord())
 			.postCount(2L)
 			.previewResponses(List.of(
-				new PostPreviewResponse(1L, 2L, "photoUrl2"),
-				new PostPreviewResponse(1L, 1L, "photoUrl1")))
+				new PostPreviewResponse(1L, 2L, 1L, "photoUrl2", false),
+				new PostPreviewResponse(1L, 1L, 1L, "photoUrl1", false)))
 			.mostPostTagRanks(List.of(
 				MostPostTagRank.builder().id(1L).count(5).name("tagName").iconUrl("iconUrl").build(),
 				MostPostTagRank.builder().id(2L).count(10).name("tagName2").iconUrl("iconUrl2").build()
@@ -140,7 +141,7 @@ public class SpotControllerDocsTest extends RestDocsSupport {
 			.postCount(10L)
 			.coord(DEFAULT_COORD)
 			.postPreviewResponses(List.of(
-				new PostPreviewResponse(3L, 1L, "image3.com")))
+				new RecentPostPreviewResponse(3L, 1L, "image3.com")))
 			.build());
 		RecommendedSpotListResponse recommendedSpotsResponse = RecommendedSpotListResponse.builder()
 			.recommendedSpots(recommendedSpotResponses)

--- a/src/test/java/com/tf4/photospot/support/TestFixture.java
+++ b/src/test/java/com/tf4/photospot/support/TestFixture.java
@@ -57,7 +57,6 @@ public class TestFixture {
 	}
 
 	public static Post createPost(Spot spot, User user, boolean isPrivate) {
-		spot.incPostCount();
 		return createPost(spot, user, createPhoto(), 0, isPrivate);
 	}
 


### PR DESCRIPTION
<!--
  제목은 `[(키워드)] (작업한 내용) - (PR 순서)` 로 작성해 주세요
  키워드 : 커밋 컨벤션에 따름
-->

## ✅ PR 타입<!-- (해당하는 타입 전체 선택) -->

- [x] 기능 추가

<br>

## 🔁 변경/추가 사항

<!-- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

- 방명록 목록 조회 시 작성자 id, 비공개 여부 정보 추가

<br>

## 🙏🏻 To Reviewers

<!-- ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

-

<br>